### PR TITLE
Add spec inheritance and composition for structure types

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -83,6 +83,45 @@ def alice : Person := { name := "Alice", age := 30 }
   .atomColor (selector := "Person") (value := "#4CAF50")
 ]
 
+/-! ## Spec Inheritance (Structure extends)
+
+Specs compose across the structure parent chain.
+Parent ops come first; child ops extend or override them.
+-/
+
+structure Vehicle where
+  make : String
+  year : Nat
+
+spytial_spec Vehicle [
+  .attribute (field := "make"),
+  .attribute (field := "year"),
+  .atomColor (selector := "Vehicle") (value := "#4CAF50"),
+  .hideAtom (selector := "String + Nat")
+]
+
+structure Car extends Vehicle where
+  doors : Nat
+
+-- Car inherits Vehicle's spec automatically (no spytial_spec needed)
+def myCar : Car := { make := "Toyota", year := 2024, doors := 4 }
+
+#spytial myCar
+
+structure ElectricCar extends Car where
+  range : Nat
+
+spytial_spec ElectricCar [
+  .attribute (field := "range"),
+  .attribute (field := "doors"),
+  .atomColor (selector := "ElectricCar") (value := "#2196F3")
+]
+
+-- ElectricCar's effective spec = Vehicle's ops ++ ElectricCar's ops
+def myTesla : ElectricCar := { make := "Tesla", year := 2025, doors := 4, range := 300 }
+
+#spytial myTesla
+
 /-! ## Lists -/
 
 def myList : List Nat := [1, 2, 3, 4]

--- a/README.md
+++ b/README.md
@@ -210,7 +210,35 @@ widget/
 
 See [DEVGUIDE.md](DEVGUIDE.md) for build details and development workflow.
 
+### Spec inheritance
+
+Specs compose across Lean's structure hierarchy. If type `B extends A`, and `A` has a `spytial_spec`, then `B` inherits it automatically. If `B` also has its own `spytial_spec`, the two are composed — parent ops first, child ops appended:
+
+```lean
+structure Vehicle where
+  make : String
+  year : Nat
+
+spytial_spec Vehicle [
+  .attribute (field := "make"),
+  .attribute (field := "year"),
+  .hideAtom (selector := "String + Nat")
+]
+
+structure ElectricCar extends Vehicle where
+  range : Nat
+
+spytial_spec ElectricCar [
+  .attribute (field := "range"),
+  .atomColor (selector := "ElectricCar") (value := "#2196F3")
+]
+
+-- Effective spec = Vehicle's ops ++ ElectricCar's ops
+#spytial myTesla
+```
+
+An explicit `with [...]` still fully overrides the inherited spec.
+
 ## TODO
 
-- Spytial specs should inherit from supertypes and compose
 - Better integration with Lean's tactic mode (`spytial` tactic, panel widgets)

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -41,12 +41,27 @@ private opaque evalSpytialSpec (stx : Syntax) : TermElabM SpytialSpec
 -/
 syntax (name := spytialCmd) "#spytial " term (" with " term)? : command
 
-/-- Try to find a Spytial spec attached to the head type of an expression. -/
+/-- Try to find a Spytial spec attached to the head type of an expression.
+    For structures, walks the parent chain and composes specs (parent-first). -/
 private def lookupTypeSpec (e : Expr) : MetaM (Option String) := do
   let ty ← inferType e
   let tyHead := (← whnf ty).getAppFn
   match tyHead with
-  | .const n _ => return getSpytialSpec? (← getEnv) n
+  | .const n _ => do
+    let env ← getEnv
+    if isStructure env n then
+      -- Walk the structure parent chain (C3 linearization, nearest-first)
+      let parents ← getAllParentStructures n
+      -- Root-first order, self last
+      let allNames := parents.reverse.toList ++ [n]
+      let yamls := allNames.filterMap (getSpytialSpec? env ·)
+      match yamls with
+      | []    => return none
+      | [one] => return some one
+      | _     => return some (mergeSpecYamls yamls)
+    else
+      -- Plain inductive — direct lookup
+      return getSpytialSpec? env n
   | _ => return none
 
 @[command_elab spytialCmd]

--- a/SpytialLean/Spec.lean
+++ b/SpytialLean/Spec.lean
@@ -146,4 +146,32 @@ def SpytialSpec.toYaml (spec : SpytialSpec) : String :=
     parts ++ ["directives:"] ++ directives.map directiveToYaml
   "\n".intercalate parts
 
+/-- Extract constraint and directive lines from a YAML spec string.
+    Returns `(constraintLines, directiveLines)`. -/
+private def extractSpecLines (yaml : String) : List String × List String :=
+  let lines := yaml.splitOn "\n"
+  let rec go (lines : List String) (inConstraints : Bool)
+      (cs : List String) (ds : List String) : List String × List String :=
+    match lines with
+    | [] => (cs.reverse, ds.reverse)
+    | l :: rest =>
+      if l == "constraints:" then go rest true cs ds
+      else if l == "directives:" then go rest false cs ds
+      else if l.startsWith "  - " then
+        if inConstraints then go rest inConstraints (l :: cs) ds
+        else go rest inConstraints cs (l :: ds)
+      else go rest inConstraints cs ds
+  go lines true [] []
+
+/-- Merge multiple YAML spec strings (parent-first order) into a single YAML spec.
+    Constraints and directives from all specs are concatenated in order. -/
+def mergeSpecYamls (yamls : List String) : String :=
+  let (allCs, allDs) := yamls.foldl (fun (cs, ds) yaml =>
+    let (c, d) := extractSpecLines yaml
+    (cs ++ c, ds ++ d)) ([], [])
+  let parts : List String := []
+  let parts := if allCs.isEmpty then parts else parts ++ ["constraints:"] ++ allCs
+  let parts := if allDs.isEmpty then parts else parts ++ ["directives:"] ++ allDs
+  "\n".intercalate parts
+
 end SpytialLean


### PR DESCRIPTION
## Summary
- `lookupTypeSpec` now walks Lean's structure parent chain via `getAllParentStructures` (C3 linearization)
- If a child structure has no spec, it inherits its parent's spec automatically
- If both parent and child have specs, they compose (parent ops first, child ops appended)
- Plain inductives (Tree, RBNode, etc.) are unaffected — direct lookup as before
- Explicit `with [...]` still fully overrides

## Test plan
- [ ] `lake build` passes
- [ ] Existing demos (RBNode, Tree, Person) still render correctly
- [ ] `#spytial myCar` renders with Vehicle's inherited spec
- [ ] `#spytial myTesla` renders with composed Vehicle + ElectricCar spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)