### PR TITLE
Add spytial tactic for tactic-mode visualization

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -144,3 +144,20 @@ def myList : List Nat := [1, 2, 3, 4]
 /-! ## Free layout (no spec) -/
 
 #spytial myTree
+
+/-! ## Tactic mode
+
+Use `spytial` as a tactic to visualize data structures mid-proof.
+Hypothesis names and local bindings are in scope.
+-/
+
+-- Visualize a hypothesis
+set_option linter.unusedVariables false in
+example (t : RBNode) : True := by
+  spytial t
+  trivial
+
+-- Inline expression with spec override
+example : True := by
+  spytial exampleRBTree
+  trivial

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -1,6 +1,7 @@
 import Lean
 import Lean.Elab.Command
 import Lean.Elab.Term
+import Lean.Elab.Tactic
 import Lean.Widget.UserWidget
 import SpytialLean.Types
 import SpytialLean.Spec
@@ -150,5 +151,46 @@ def elabSpytialDatumDebug : CommandElab := fun
     let json := toJson dataInstance
     logInfo m!"{json.pretty}"
   | stx => throwError "Unexpected syntax {stx}."
+
+/-! ## spytial tactic -/
+
+open Tactic in
+/-- `spytial <term>` displays a spatial relational diagram in the Lean infoview
+    during tactic mode. Hypothesis names and local bindings are in scope.
+
+    Use `spytial <term> with [<ops>]` to specify layout operations, just like the
+    `#spytial` command.
+
+    ```
+    example (t : RBTree Nat) : True := by
+      spytial t
+      trivial
+    ```
+-/
+syntax (name := spytialTactic) "spytial " term (" with " term)? : tactic
+
+open Tactic in
+@[tactic spytialTactic]
+def elabSpytialTactic : Tactic := fun stx => do
+    let t := stx[1]
+    let specOpt := stx[2]
+    let e ← Term.elabTerm t none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let e ← instantiateMVars e
+    let di ← relationalize e
+    let yaml ← if specOpt.isNone then
+        lookupTypeSpec e
+      else
+        let specTerm := specOpt[1]!
+        let spec ← evalSpytialSpec specTerm
+        pure (some (SpytialSpec.toYaml spec))
+
+    let props : Json := Json.mkObj <|
+      [("dataInstance", toJson di)] ++
+      match yaml with
+      | some s => [("cndSpec", toJson s)]
+      | none => []
+
+    savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
 
 end SpytialLean


### PR DESCRIPTION
## Summary
- Adds a `spytial` tactic that displays spatial relational diagrams in the Lean infoview during tactic mode
- Reuses all existing infrastructure (relationalizer, spec system, widget) — the tactic is a ~30 line adapter in `Command.lean`
- Supports `spytial <term>` and `spytial <term> with [<ops>]`, with hypothesis names and local bindings in scope

### Usage
```lean
example (t : RBNode) : True := by
  spytial t          -- renders diagram in infoview
  trivial

example : True := by
  spytial exampleRBTree
  trivial
```

## Test plan
- [x] `lake build` succeeds
- [x] `Demo.lean` compiles with tactic-mode examples
- [ ] Open Demo.lean in VS Code and verify diagrams render in infoview when cursor is on `spytial` tactic lines
- [ ] Test with explicit `with [...]` spec override in tactic mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)