### PR TITLE
Add proof visualization mode: #spytial.proof

### DIFF
--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -181,6 +181,59 @@ def elabSpytialDatumDebug : CommandElab := fun
     logInfo m!"{json.pretty}"
   | stx => throwError "Unexpected syntax {stx}."
 
+/-! ## Proof visualization -/
+
+/-- `#spytial.proof <term>` visualizes a proof term without filtering Prop-typed fields.
+    Unlike `#spytial` (data mode), this shows the full proof structure — sub-proofs,
+    premises, and witnesses are all included as nodes and edges.
+
+    Use `with [...]` to specify layout operations.
+-/
+syntax (name := spytialProofCmd) "#spytial.proof " term (" with " term)? : command
+
+@[command_elab spytialProofCmd]
+def elabSpytialProofCmd : CommandElab := fun
+  | stx@`(#spytial.proof $t:term $[with $spec?]?) => do
+    let (dataInstance, specYaml) ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      let di ← relationalize e { filterProofs := false }
+      let yaml ← match spec? with
+        | some specTerm => do
+          let spec ← evalSpytialSpec specTerm
+          pure (some (SpytialSpec.toYaml spec))
+        | none => lookupTypeSpec e
+      return (di, yaml)
+
+    let props : Json := Json.mkObj <|
+      [("dataInstance", toJson dataInstance)] ++
+      match specYaml with
+      | some s => [("cndSpec", toJson s)]
+      | none => []
+
+    liftCoreM <| savePanelWidgetInfo
+      SpytialWidget.javascriptHash
+      (return props)
+      stx
+
+  | stx => throwError "Unexpected syntax {stx}."
+
+/-- `#spytial.proof.datum <term>` prints the JSON data instance in proof mode. -/
+syntax (name := spytialProofDatumDebug) "#spytial.proof.datum " term : command
+
+@[command_elab spytialProofDatumDebug]
+def elabSpytialProofDatumDebug : CommandElab := fun
+  | `(#spytial.proof.datum $t:term) => do
+    let dataInstance ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      relationalize e { filterProofs := false }
+    let json := toJson dataInstance
+    logInfo m!"{json.pretty}"
+  | stx => throwError "Unexpected syntax {stx}."
+
 /-! ## spytial tactic -/
 
 open Tactic in
@@ -207,6 +260,37 @@ def elabSpytialTactic : Tactic := fun stx => do
     Term.synthesizeSyntheticMVarsNoPostponing
     let e ← instantiateMVars e
     let di ← relationalize e
+    let yaml ← if specOpt.isNone then
+        lookupTypeSpec e
+      else
+        let specTerm := specOpt[1]!
+        let spec ← evalSpytialSpec specTerm
+        pure (some (SpytialSpec.toYaml spec))
+
+    let props : Json := Json.mkObj <|
+      [("dataInstance", toJson di)] ++
+      match yaml with
+      | some s => [("cndSpec", toJson s)]
+      | none => []
+
+    savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
+
+/-! ## Proof tactic -/
+
+open Tactic in
+/-- `spytial.proof <term>` visualizes a proof term in tactic mode,
+    showing the full proof structure without filtering Prop-typed fields. -/
+syntax (name := spytialProofTactic) "spytial.proof " term (" with " term)? : tactic
+
+open Tactic in
+@[tactic spytialProofTactic]
+def elabSpytialProofTactic : Tactic := fun stx => do
+    let t := stx[1]
+    let specOpt := stx[2]
+    let e ← Term.elabTerm t none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let e ← instantiateMVars e
+    let di ← relationalize e { filterProofs := false }
     let yaml ← if specOpt.isNone then
         lookupTypeSpec e
       else

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -39,6 +39,11 @@ def WalkState.toDataInstance (s : WalkState) : JsonDataInstance :=
     { id := name, name := name, types := types, tuples := tuples : JsonRelation }
   { atoms := s.atoms, relations := relations }
 
+/-- Configuration for the expression walker. -/
+structure WalkConfig where
+  /-- When true, skip Prop-typed fields (data mode). When false, show them (proof mode). -/
+  filterProofs : Bool := true
+
 /-- Check if an expression is a proof or type (erased at runtime). -/
 def isProofArg (e : Expr) : MetaM Bool := do
   let ty ← inferType e
@@ -120,7 +125,7 @@ def tryEnumerateDomain (ty : Expr) : MetaM (Option (Array (String × Expr))) := 
 
 /-- Walk a Lean expression and produce atoms + relations.
     Returns the atom ID assigned to this expression. -/
-partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
+partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState MetaM String := do
   -- Save original name before WHNF unfolds it
   let origName := eOrig.getAppFn.constName?
   -- WHNF reduce to expose constructors
@@ -144,7 +149,7 @@ partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
   let tyWhnfForLookup ← Meta.whnf ty
   if let .const typeConstName _ := tyWhnfForLookup.getAppFn then
     if let some relFn ← getSpytialRelationalizer? typeConstName then
-      return ← relFn eOrig walkExpr
+      return ← relFn eOrig (walkExpr cfg)
 
   -- Dispatch by expression form
   match e with
@@ -175,7 +180,7 @@ partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
     | some elems =>
       for (elemLabel, elemExpr) in elems do
         let result ← Meta.whnf (Expr.app e elemExpr)
-        let childId ← walkExpr result
+        let childId ← walkExpr cfg result
         modify fun s => s.addTuple elemLabel #[typeName, typeName]
           { atoms := #[atomId, childId], types := #[typeName, typeName] }
     | none => pure ()  -- non-finite domain, just a labeled node
@@ -212,9 +217,9 @@ partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
         let dataArgs := args.extract numParams args.size
         for i in [:dataArgs.size] do
           let arg := dataArgs[i]!
-          let isProof ← isProofArg arg
+          let isProof ← if cfg.filterProofs then isProofArg arg else pure false
           unless isProof do
-            let childId ← walkExpr arg
+            let childId ← walkExpr cfg arg
             -- Use the binder name if available, otherwise fall back to index
             let fieldName :=
               if h : i < binderNames.size then
@@ -239,10 +244,10 @@ partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
         modify fun s => s.addAtom { id := atomId, type := typeName, label := typeName }
         for fieldName in fields do
           let proj ← Meta.mkProjection e fieldName
-          let isProof ← isProofArg proj
+          let isProof ← if cfg.filterProofs then isProofArg proj else pure false
           unless isProof do
             let projReduced ← Meta.whnf proj
-            let childId ← walkExpr projReduced
+            let childId ← walkExpr cfg projReduced
             let fn := toString fieldName
             modify fun s => s.addTuple fn #[typeName, typeName]
               { atoms := #[atomId, childId], types := #[typeName, typeName] }
@@ -259,8 +264,8 @@ partial def walkExpr (eOrig : Expr) : StateT WalkState MetaM String := do
       return atomId
 
 /-- Walk an expression and produce a complete JsonDataInstance. -/
-def relationalize (e : Expr) : MetaM JsonDataInstance := do
-  let (_, state) ← walkExpr e |>.run {}
+def relationalize (e : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do
+  let (_, state) ← walkExpr cfg e |>.run {}
   return state.toDataInstance
 
 end SpytialLean

--- a/demos/HoareLogic.lean
+++ b/demos/HoareLogic.lean
@@ -1,0 +1,66 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Hoare Logic Proof Trees
+
+Hoare triples {P} S {Q} compose into proof trees.
+Can we visualize the structure of a Hoare proof?
+
+Inspired by Ch 9 of "The Hitchhiker's Guide to Logical Verification".
+-/
+
+/-! ## Reusing the language from OperationalSemantics -/
+
+abbrev VarName' := String
+abbrev State' := VarName' → Int
+
+def State'.update (σ : State') (x : VarName') (v : Int) : State' :=
+  fun y => if y == x then v else σ y
+
+inductive Expr' where
+  | lit (n : Int)
+  | var (x : VarName')
+  | add (e₁ e₂ : Expr')
+
+inductive Stmt' where
+  | skip
+  | assign (x : VarName') (e : Expr')
+  | seq (s₁ s₂ : Stmt')
+
+def evalExpr' : Expr' → State' → Int
+  | .lit n, _ => n
+  | .var x, σ => σ x
+  | .add e₁ e₂, σ => evalExpr' e₁ σ + evalExpr' e₂ σ
+
+/-! ## Hoare triples as an inductive type -/
+
+/-- A Hoare triple {P} S {Q} is valid if for all states σ,
+    P σ → (S terminates in σ') → Q σ'. -/
+inductive HoareTriple : (State' → Prop) → Stmt' → (State' → Prop) → Prop where
+  | skip {P} : HoareTriple P .skip P
+  | assign {Q x e} : HoareTriple (fun σ => Q (σ.update x (evalExpr' e σ)))
+      (.assign x e) Q
+  | seq {P R Q s₁ s₂} : HoareTriple P s₁ R → HoareTriple R s₂ Q →
+      HoareTriple P (.seq s₁ s₂) Q
+  | conseq {P P' Q Q' s} : (∀ σ, P' σ → P σ) → HoareTriple P s Q →
+      (∀ σ, Q σ → Q' σ) → HoareTriple P' s Q'
+
+/-! ## A concrete Hoare proof -/
+
+-- Program: x := 1; y := x + 2
+-- Prove: {True} x := 1; y := x + 2 {y = 3}
+
+def hoare_proof : HoareTriple
+    (fun _ => True)
+    (.seq (.assign "x" (.lit 1))
+          (.assign "y" (.add (.var "x") (.lit 2))))
+    (fun σ => σ "y" = 3) :=
+  .conseq
+    (fun _ _ => by simp [State'.update, evalExpr'])
+    (.seq .assign .assign)
+    (fun _ h => h)
+
+-- The proof tree: conseq → (weakening, seq → (assign, assign), strengthening)
+#spytial.proof hoare_proof
+#spytial.proof.datum hoare_proof

--- a/demos/OperationalSemantics.lean
+++ b/demos/OperationalSemantics.lean
@@ -1,0 +1,72 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Operational Semantics — Derivation Trees
+
+A minimalistic imperative language with big-step semantics.
+Derivation trees show *why* a program evaluates to a result.
+
+Inspired by Ch 8 of "The Hitchhiker's Guide to Logical Verification".
+-/
+
+/-! ## A tiny imperative language -/
+
+-- Variables are just strings
+abbrev VarName := String
+
+-- Expressions
+inductive Expr where
+  | lit (n : Int)
+  | var (x : VarName)
+  | add (e₁ e₂ : Expr)
+
+-- Statements
+inductive Stmt where
+  | skip
+  | assign (x : VarName) (e : Expr)
+  | seq (s₁ s₂ : Stmt)
+  | ite (cond : Expr) (thn els : Stmt)
+
+-- State is a map from variable names to values
+abbrev State := VarName → Int
+
+def State.update (σ : State) (x : VarName) (v : Int) : State :=
+  fun y => if y == x then v else σ y
+
+/-! ## Expression evaluation (total function) -/
+
+def evalExpr : Expr → State → Int
+  | .lit n, _ => n
+  | .var x, σ => σ x
+  | .add e₁ e₂, σ => evalExpr e₁ σ + evalExpr e₂ σ
+
+/-! ## Big-step semantics as an inductive predicate -/
+
+inductive BigStep : Stmt → State → State → Prop where
+  | skip {σ} : BigStep .skip σ σ
+  | assign {σ x e} : BigStep (.assign x e) σ (σ.update x (evalExpr e σ))
+  | seq {s₁ s₂ σ σ' σ''} : BigStep s₁ σ σ' → BigStep s₂ σ' σ'' →
+      BigStep (.seq s₁ s₂) σ σ''
+  | ite_true {cond thn els σ σ'} : evalExpr cond σ ≠ 0 → BigStep thn σ σ' →
+      BigStep (.ite cond thn els) σ σ'
+  | ite_false {cond thn els σ σ'} : evalExpr cond σ = 0 → BigStep els σ σ' →
+      BigStep (.ite cond thn els) σ σ'
+
+/-! ## A concrete program and its derivation -/
+
+-- Program: x := 1; y := x + 2
+def prog1 : Stmt :=
+  .seq (.assign "x" (.lit 1))
+       (.assign "y" (.add (.var "x") (.lit 2)))
+
+def emptyState : State := fun _ => 0
+
+-- The derivation tree for this program
+def prog1_derivation : BigStep prog1 emptyState
+    ((emptyState.update "x" 1).update "y" 3) :=
+  .seq .assign .assign
+
+-- Can we see the tree: seq → (assign x=1, assign y=3)?
+#spytial.proof prog1_derivation
+#spytial.proof.datum prog1_derivation

--- a/demos/ProofTerms.lean
+++ b/demos/ProofTerms.lean
@@ -1,0 +1,68 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Proof Term Visualization
+
+In Lean, proofs are terms. Spytial visualizes terms.
+Therefore: Spytial can visualize proof structures.
+
+This demo explores what proof terms look like when visualized.
+-/
+
+/-! ## Reflexive Transitive Closure (Star)
+
+A classic inductive predicate. A proof of `Star r a c` is a
+chain of steps: a → b → ... → c. Can we see the chain? -/
+
+inductive Star {α : Type} (r : α → α → Prop) : α → α → Prop where
+  | refl : Star r a a
+  | step : r a b → Star r b c → Star r a c
+
+-- A simple "successor" relation on Nat
+inductive Step : Nat → Nat → Prop where
+  | mk : Step n (n + 1)
+
+-- Proof that 0 can reach 3 via Step
+def zeroToThree : Star Step 0 3 :=
+  .step .mk (.step .mk (.step .mk .refl))
+
+-- Can we see the chain 0 → 1 → 2 → 3?
+#spytial.proof zeroToThree
+#spytial.proof.datum zeroToThree
+
+/-! ## Even predicate
+
+Another classic — proof that a number is even is either
+`zero` or `add_two` applied to a smaller proof. -/
+
+inductive MyEven : Nat → Prop where
+  | zero : MyEven 0
+  | add_two : MyEven n → MyEven (n + 2)
+
+def even_six : MyEven 6 :=
+  .add_two (.add_two (.add_two .zero))
+
+-- Should show a chain: add_two → add_two → add_two → zero
+#spytial.proof even_six
+#spytial.proof.datum even_six
+
+/-! ## List membership proof
+
+A proof that an element is in a list has structure too. -/
+
+def three_in_list : 3 ∈ [1, 2, 3, 4, 5] := by decide
+
+#spytial.proof three_in_list
+
+/-! ## Simple logical proof terms -/
+
+-- An And.intro has two sub-proofs
+def and_proof : True ∧ True := ⟨trivial, trivial⟩
+#spytial.proof and_proof
+#spytial.proof.datum and_proof
+
+-- An Or.inl / Or.inr shows which branch was taken
+def or_proof : True ∨ False := Or.inl trivial
+#spytial.proof or_proof
+#spytial.proof.datum or_proof


### PR DESCRIPTION
## Summary

Proofs are terms. Spytial visualizes terms. **`#spytial.proof` visualizes proof structures** — derivation trees, inductive predicate chains, Hoare logic proof trees. This is the Lean-native analogue of CLRS data structure visualization.

### The fundamental distinction

| | `#spytial` (data mode) | `#spytial.proof` (proof mode) |
|---|---|---|
| **Object** | The value (a tree, a list) | The proof structure (a derivation) |
| **Constructors** | Node types (leaf, node) | Rule names (step, refl, seq) |
| **Prop fields** | Noise — filtered | Premises — shown |
| **Layout goal** | Data shape | Derivation tree |

### Changes
- Adds `WalkConfig` struct with `filterProofs : Bool` threaded through `walkExpr`
- `#spytial` uses `filterProofs := true` (unchanged behavior)
- `#spytial.proof` uses `filterProofs := false` (shows full proof structure)
- New commands: `#spytial.proof`, `#spytial.proof.datum`, `spytial.proof` tactic
- All support `with [...]` inline specs

### Results
- `Star Step 0 3` now shows the full chain: step→step→step→refl with intermediate values 0,1,2,3
- `MyEven 6` shows: add_two(4)→add_two(2)→add_two(0)→zero
- `And.intro` shows both sub-proofs; `Or.inl` shows the chosen branch
- `BigStep.seq` shows the full derivation tree

Closes #18

## Test plan
- [x] `lake build Demos` passes (23 jobs)
- [x] `#spytial.proof.datum zeroToThree` shows full Star chain (was truncated)
- [x] `#spytial.proof.datum even_six` shows full Even chain (was single node)
- [x] `#spytial.proof.datum and_proof` shows both sub-proofs (was empty)
- [x] Existing data demos (`Showcase`, `ProofFieldFiltering`) still filter proofs (no regression)
- [ ] Open proof demos in VS Code — verify visualizations render

🤖 Generated with [Claude Code](https://claude.com/claude-code)