### PR TITLE
Roadmap batch: implement 8 open issues, verify 1, defer 1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,153 @@
+# spytial-lean roadmap plan
+
+This document records the design decisions for the open issue backlog and tracks
+implementation status. It is maintained in-repo so decisions survive the PRs that
+implement them. Last updated: 2026-06-10.
+
+## Guiding principles
+
+1. **Selectors must stay stable.** The `type` field of an atom is part of the
+   user-facing spec API (selectors match on it). Features may enrich *labels*
+   freely, but must not change existing `type` strings or relation names.
+2. **No Mathlib dependency in the core library or default demos.** Anything that
+   needs `Fintype`, `Subgroup`, etc. lives in a separate, optional project.
+3. **Relationalizer behavior changes must be strict improvements.** Where a term
+   today renders as an opaque leaf, decomposing it further is fine. Where it
+   already decomposes, the default output must not change shape (opt-in only).
+4. **Spec ops that affect the relationalizer (not the widget) are partitioned
+   out of the YAML** and become `WalkConfig` fields. The YAML remains exactly
+   what spytial-core's `parseLayoutSpec` understands.
+
+## Decisions and status
+
+### #22 — Surface DAG-shared subterms — **DONE (this PR)**
+
+**Decision: Option 1 (shared flag), least invasive.**
+`WalkState.seen` already deduplicates by `Expr.hash`. On a second visit we now
+mark the existing atom `shared := true`. `JsonAtom.shared` serializes as an
+extra JSON field, which spytial-core ignores today; the flag is visible in
+`#spytial.datum` output, and a `demos/Sharing.lean` demo documents the
+behavior. Distinct visual styling (dashed border) belongs in spytial-core and
+is deferred there — the data already carries the flag it would need.
+
+### #9 — Quotient type visualization — **DONE (this PR)**
+
+**Decision: detect `Quot.mk`-headed terms, walk the representative.**
+`Quot` is kernel-primitive (`.quotInfo`, not `.ctorInfo`), so the constructor
+dispatch misses it and it falls through to an opaque leaf. We special-case
+applications headed by `Quot.mk` / `Quotient.mk` / `Quotient.mk'`: the atom is
+labeled `⟦·⟧`, typed by the quotient type's head name, and the underlying
+representative is walked as a child via a `repr` relation. The equivalence-class
+view (multiple representatives grouped) is a stretch goal, deferred.
+
+### #21 — Indices of indexed inductive families — **DONE (this PR)**
+
+**Decision: surface indices in the atom label; keep `type` stable.**
+When a constructor's inductive has `numIndices > 0`, we read the index
+expressions off the value's *type* (the trailing `numIndices` arguments) and
+append them to the label: `cons : Vec 2`. The `type` field stays the head
+constant's short name, so existing selectors are unaffected. The synthetic
+`__index_n` relation and spec-projected variants from the issue are rejected:
+indices are type-level data, and edges to them would suggest runtime structure
+that isn't there.
+
+### #13 — Structural decomposition of function bodies — **DONE (this PR)**
+
+**Decision: structural decomposition only where today we show a leaf.**
+Finite-domain enumeration (the #6 behavior) remains the default for enumerable
+domains — extensional view first. For *non-finite* domains, where today the
+lambda is an opaque labeled node, we enter the binder (`withLocalDecl`),
+`whnfCore` the body, and decompose:
+
+- `ite` / `dite` → node labeled `if`, edges `condition` / `then` / `else`
+- `T.casesOn` applications → node labeled `match`, edge `match` to the
+  discriminant, one edge per branch labeled by constructor name
+- `Expr.letE` → edges `let_value` / `let_body`
+- nested lambdas → recurse (multi-argument functions)
+
+Anything else falls back to the current leaf label. A spec flag to force one
+view or the other is deferred until someone asks for it.
+
+### #8 — Finite type enumeration — **DONE (this PR)**
+
+**Decision: `#spytial.enumerate <Type>` command, no `Fintype`, no `#spytial.map`.**
+The issue proposes `[Fintype α]`, but `Fintype` is Mathlib — violates
+principle 2. We already have `tryEnumerateDomain` (Bool, `Fin n` for n ≤ 20,
+zero-arity enum inductives); the new command elaborates its argument as a type,
+enumerates the inhabitants, and walks them all into a single shared diagram
+(so a function field pointing at an enumerated element unifies with it).
+`#spytial.map f` is unnecessary: `#spytial f` already enumerates finite
+domains via the lambda arm — the demo shows this. Non-enumerable types get a
+clear error naming what is supported.
+
+### #2 — Spec lookup for parent-child relationships — **PARTIAL (this PR)**
+
+**Decision: type classes work through the existing structure path; verify and
+demo it; defer the rest.** Lean 4 classes *are* structures, so
+`lookupTypeSpec`'s parent-chain walk already covers `class B extends A`.
+This PR adds a demo proving it (spec on a parent class applies to a child
+class instance). Deferred with rationale:
+
+- *Explicit `spytial_spec RBNode extends Tree`*: new syntax for a niche need;
+  wait for demand.
+- *Per-instantiation specs (`List Nat` vs `List`)*: the spec store is keyed by
+  `Name`; keying by type expression is a storage-format migration. Follow-up.
+- *Subtype inheritance*: `{x : Nat // x > 0}` is headed by `Subtype`, and
+  values are `Subtype.mk` pairs — inheriting the base type's spec silently
+  would mislabel the wrapper atom. Needs its own design.
+
+Issue stays open for the deferred cases.
+
+### #24 — Notation-aware atom labels — **DONE (this PR)**
+
+**Decision: route 1, per-spec opt-in via a new `.notationLabel` op.**
+New op `.notationLabel (selector := "<TypeHeadName>")`. It is neither a
+constraint nor a directive: per principle 4 it never reaches the YAML.
+`#spytial`'s elaborator partitions it into `WalkConfig.collapseTypes`; when the
+walker reaches an expression whose type-head short name matches, it emits a
+single atom labeled with the *pre-whnf* pretty-printed expression (the
+delaborator restores `[1, 2, 3]`, `(a, b)`, `a + b`) and does not decompose.
+Limitation, documented: works in `with [...]` blocks only. Type-attached specs
+(`spytial_spec`) store YAML, so relationalizer-side ops can't round-trip
+through them until the storage format carries structured ops — follow-up.
+
+### #23 — Term-size limits — **DONE (this PR)**
+
+**Decision: measure, document, and add a `maxAtoms` guard.**
+`WalkConfig.maxAtoms : Nat := 5000`; exceeding it throws a clear error rather
+than hanging the editor. Benchmarks (relationalize time for `List.range N`,
+a deep RBNode, a proof term) are recorded in the README "Performance and
+limits" section with measured numbers and soft guidance.
+
+### #10 — Proof-state visualization (`spytial_goals`) — **DONE (this PR)**
+
+**Decision: ship the basic tactic, mark it experimental.**
+`spytial_goals` walks the local context and goals of the current proof state:
+
+- Hypotheses whose type is a const-headed Prop application `R a b …` become
+  tuples in a relation named `R` (data args walked as atoms, proof args
+  skipped).
+- Data-typed hypotheses are relationalized normally.
+- Goals get the same treatment, but their relations are prefixed `⊢ ` so specs
+  can style hypothesis vs. goal differently.
+
+Tactic diff (before/after), dependency highlighting, and interactivity are
+stretch goals and stay in the issue.
+
+### #20 — Mathlib smoke-test demo — **DEFERRED**
+
+**Decision: separate project, separate PR.** Even an optional `lean_lib` in
+this lakefile would force Mathlib onto every `lake update` resolution and CI
+run (multi-GB artifacts). The right shape is a standalone `demos-mathlib/`
+lake project that `require`s both spytial-lean and Mathlib, exercised manually
+or in a dedicated CI job with `lake exe cache get`. It also genuinely needs a
+human looking at the rendered output (screenshots in the PR), which is the
+point of the issue. Stays open.
+
+## Execution notes
+
+- Agents work sequentially on one checkout (lake builds can't safely run
+  concurrently in one dir); each change is verified with `lake build`
+  (library + demos) before commit.
+- Every feature lands with a demo file registered in the `Demos` lib roots in
+  `lakefile.lean`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,25 @@
 
 This document records the design decisions for the open issue backlog and tracks
 implementation status. It is maintained in-repo so decisions survive the PRs that
-implement them. Last updated: 2026-06-10.
+implement them. Last updated: 2026-06-11.
+
+## Status at a glance
+
+| Issue | Feature | Status |
+|-------|---------|--------|
+| #22 | DAG-shared subterm flag | ✅ done |
+| #9 | Quotient type visualization | ✅ done |
+| #21 | Indexed-family index labels | ✅ done |
+| #13 | Structural function-body decomposition | ✅ done |
+| #8 | `#spytial.enumerate` finite types | ✅ done |
+| #24 | `.notationLabel` surface-syntax collapse | ✅ done |
+| #2 | Type-class spec inheritance | ✅ verified; rest deferred |
+| #23 | `maxAtoms` guard + benchmarks | ✅ done |
+| #10 | `spytial_goals` proof-state tactic | ✅ done (experimental) |
+| #20 | Mathlib smoke-test demo | 🔵 deferred (separate project) |
+
+Each landed feature ships with a demo under `demos/` registered in the `Demos`
+lib roots, and was verified with `lake build` + `lake build Demos`.
 
 ## Guiding principles
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,56 @@ Use `#spytial.datum` and `#spytial.spec` to inspect what the relationalizer and 
 ]
 ```
 
+## Performance and limits
+
+`walkExpr` is recursive and unbounded by depth; its cost scales with the number
+of atoms produced — roughly the number of constructor nodes after WHNF, minus
+shared subterms (structurally identical subterms are deduplicated into a single
+atom via the `seen` cache).
+
+Indicative timings, measured on a dev laptop (relationalize only — these are not
+rigorous benchmarks, and the widget's own layout step is separate and slower):
+
+| Input | Atoms | `relationalize` time |
+|-------|-------|----------------------|
+| `List.range 10` | 21 | < 5 ms |
+| `List.range 100` | 201 | ~ 3 ms |
+| `List.range 1000` | 2001 | ~ 40 ms |
+| Balanced binary tree, depth 5 (31 nodes, distinct leaves) | 47 | < 1 ms |
+| `Nat.add_comm 100 200` (proof mode, `filterProofs := false`) | 1 | < 1 ms |
+
+Relationalization itself stays fast into the low thousands of atoms. In practice
+the limit you hit first is legibility: under a few hundred atoms the diagram
+renders comfortably, but into the thousands the layout step inside the widget
+becomes the bottleneck and the picture is rarely readable anyway.
+
+### The `maxAtoms` guard
+
+`WalkConfig.maxAtoms` (default `5000`) caps the total number of atoms a single
+walk may produce. When a walk would exceed it, the relationalizer throws rather
+than building a runaway diagram (or hanging the editor):
+
+```
+spytial: relationalize produced over 5000 atoms (the WalkConfig.maxAtoms limit
+was hit); the term is too large to visualize usefully. Increase the limit via
+WalkConfig.maxAtoms, or visualize a smaller sub-term.
+```
+
+This guard bounds the **relationalizer**; the widget's own layout cost is a
+separate concern and is not affected by it. The default of 5000 is far above
+anything that renders usefully, so ordinary use never trips it — raise it
+deliberately if you genuinely need a larger diagram.
+
+### A note on unfolding
+
+`#spytial` decomposes a term *after* `Meta.whnf`, so definitions unfold before
+they are walked. A small-looking term can therefore expand a lot: `List.range
+1000` is three tokens but relationalizes to 2001 atoms. Proof terms are the
+surprising case in the other direction — a theorem like `Nat.add_comm 100 200`
+stays a single atom even in proof mode, because `whnf` does not unfold a
+theorem's body (proofs are opaque to it). So a proof that *looks* large may
+collapse to one node, while a tiny data definition may explode.
+
 ## Available operations
 
 Operations are constructors of `SpytialOp`. Pass them as a list to `with [...]` or `spytial_spec`.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,46 @@ Use `#spytial.datum` and `#spytial.spec` to inspect what the relationalizer and 
 ]
 ```
 
+## Commands and tactics
+
+Beyond `#spytial <term>` and the `spytial <term>` tactic, the library provides:
+
+| Form | Purpose |
+|------|---------|
+| `#spytial <term> with [...]` | Visualize a value (the core command). |
+| `#spytial.proof <term>` | Visualize a proof term — shows `Prop`-typed sub-proofs that `#spytial` filters out. |
+| `#spytial.enumerate <Type>` | Visualize **all** inhabitants of a finite type in one diagram. Enumerable types: `Bool`, `Fin n` (`n ≤ 20`), and inductive types whose constructors all take no arguments. No `Fintype` instance required. |
+| `spytial <term>` / `spytial.proof <term>` | The same, in tactic mode (hypotheses in scope). |
+| `spytial_goals` | **Experimental.** Render the current proof state — hypotheses and goals — as one relational diagram. First-order `Prop` hypotheses `R a b` become relation edges; goal relations are prefixed `⊢ `. See [issue #10](https://github.com/sidprasad/spytial-lean/issues/10). |
+
+Each command has a `.datum` debugging counterpart that prints JSON instead of
+opening the widget: `#spytial.datum`, `#spytial.proof.datum`,
+`#spytial.enumerate.datum`, and the `spytial_goals_datum` tactic.
+`#spytial.typespec <term>` prints the spec YAML resolved for a term's type
+(including inherited specs).
+
+```lean
+inductive Direction | north | south | east | west
+#spytial.enumerate Direction   -- four atoms, one per constructor
+
+-- A finite function is already enumerated by #spytial (no #spytial.map needed):
+def turn : Direction → Direction
+  | .north => .east | .east => .south | .south => .west | .west => .north
+#spytial turn                  -- the full mapping as edges
+```
+
+Notation-aware labels collapse the underlying constructor chain back to surface
+syntax:
+
+```lean
+#spytial ([1, 2, 3] : List Nat) with [.notationLabel (selector := "List")]
+-- one atom labeled `[1, 2, 3]` instead of a four-atom cons/nil chain
+```
+
+See the [`demos/`](demos/) directory for runnable examples of every feature,
+including DAG sharing, quotient types, indexed families (`Vec n`), and
+structural decomposition of function bodies.
+
 ## Performance and limits
 
 `walkExpr` is recursive and unbounded by depth; its cost scales with the number
@@ -218,6 +258,16 @@ Operations are constructors of `SpytialOp`. Pass them as a list to `with [...]` 
 | `.tag (toTag) (name) (value)` | Add computed attributes to nodes |
 | `.inferredEdge (name) (selector)` | Add edges that don't exist in the data |
 | `.flag (name)` | Set a boolean flag (e.g., `hideDisconnected`) |
+
+### Relationalizer ops
+
+These configure the *walk* rather than the widget, so they never appear in the
+emitted YAML. They are only valid in a `with [...]` block (not in a type-attached
+`spytial_spec`).
+
+| Operation | Description |
+|-----------|-------------|
+| `.notationLabel (selector)` | Collapse values whose type-head matches the selector into a single atom labeled with their surface notation — e.g. `.notationLabel (selector := "List")` renders `[1, 2, 3]` as one atom instead of a `cons` chain. Selectors use the type **head** name (`List`, `Prod`), not the applied type. |
 
 ### Direction values
 

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -452,4 +452,240 @@ def elabSpytialProofTactic : Tactic := fun stx => do
 
     savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
 
+/-! ## Proof-state tactic -/
+
+/-- Resolve a human-readable relation name from the head of a Prop application,
+    or `none` if the head is not something we name a relation after.
+
+    - A `.const R` head yields `R`'s short name (e.g. `LT.lt` → `lt`).
+    - A `.fvar` head yields the local declaration's user-facing name. This is the
+      common case for proof-state goals: a relation introduced by `variable (R :
+      α → α → Prop)` or a binder is a *free variable*, NOT a constant, so without
+      this branch `R x y` would never become a relation. The fvar must be in the
+      ambient local context (this runs inside `mvarId.withContext`).
+    - Anything else (a `∀`/`→`/`∧` whose head is not an application of a named
+      symbol) yields `none`, so the caller falls back to skipping / a `Goal`
+      atom. -/
+private def relNameOfHead? (head : Expr) : MetaM (Option String) := do
+  match head with
+  | .const n _ => return some (shortName n)
+  | .fvar fvarId =>
+    match (← getLCtx).find? fvarId with
+    | some decl => return some (shortName decl.userName)
+    | none      => return none
+  | _ => return none
+
+/-- Walk a Prop application `R a₁ … aₙ` (headed by a constant or a local free
+    variable) as a relation tuple.
+
+    Given an expression `ty` (a hypothesis or goal *type*), this:
+
+    - returns `false` (decomposed nothing) unless `ty` is `Meta.isProp` and its
+      head is a constant or local fvar `R` (see `relNameOfHead?` — local
+      relations from `variable (R : …)` are fvars, so both are accepted);
+    - filters the arguments to the non-proof, non-type *data* args (reusing the
+      same `isProofArg` predicate the value walker uses);
+    - if ≥ 2 data args survive, walks each as an atom via `walkExpr` and adds ONE
+      tuple to a relation named `{prefix}{R}` connecting them in order, returning
+      `true`;
+    - if exactly 1 data arg survives, walks it as a lone atom (it appears in the
+      diagram but carries no edge — a unary relation has no endpoints) and
+      returns `true`;
+    - if 0 data args survive, emits nothing and returns `false`.
+
+    `pfx` is prepended to the relation name: hypotheses pass `""`, goals pass
+    `"⊢ "`, so specs can style goal edges differently from hypothesis edges. The
+    relation name is R's short name, NOT the hypothesis binder name — the
+    relation carries the meaning, and the binder name is intentionally dropped
+    for now (a deliberate simplification; see the `spytial_goals` docstring). -/
+private def walkPropApp (cfg : WalkConfig) (pfx : String) (ty : Expr) :
+    StateT WalkState MetaM Bool := do
+  -- Only const-/fvar-headed Prop applications become relations.
+  unless ← Meta.isProp ty do return false
+  let some rName ← relNameOfHead? ty.getAppFn | return false
+  let relName := pfx ++ rName
+  -- Keep only the genuine data arguments. Drop proofs and types (as the value
+  -- walker does), AND drop instance arguments: a notation-class application like
+  -- `a < b` desugars to `@LT.lt Nat instLTNat a b`, and the `instLTNat` instance
+  -- is `Type`-valued (not a proof or sort) so it survives `isProofArg`. Walking
+  -- it would inject a spurious `LT.mk` node and make `lt` a 3-ary `[inst, a, b]`
+  -- relation instead of the intended binary `a → b`.
+  let args := ty.getAppArgs
+  let mut dataArgs : Array Expr := #[]
+  for a in args do
+    if ← isProofArg a then continue
+    -- Skip instances (arguments whose type is a type class).
+    if (← Meta.isClass? (← Meta.inferType a)).isSome then continue
+    dataArgs := dataArgs.push a
+  if dataArgs.size == 0 then
+    -- Nothing to anchor a relation on (e.g. `R` is a 0-ary or all-proof prop).
+    return false
+  -- Walk every surviving data arg into the shared diagram.
+  let mut ids : Array String := #[]
+  for a in dataArgs do
+    let id ← walkExpr cfg a
+    ids := ids.push id
+  if dataArgs.size == 1 then
+    -- A single data arg can't form an edge; its atom is already in the diagram.
+    return true
+  -- ≥ 2 data args: connect them in order with one tuple.
+  let types := Array.replicate ids.size relName
+  modify fun s => s.addTuple relName types { atoms := ids, types := types }
+  return true
+
+open Tactic in
+/-- `spytial_goals` renders the CURRENT proof state — all goals and their local
+    hypotheses — as a single spatial relational diagram in the Lean infoview.
+
+    For each goal (and inside each goal's own context, so hypotheses resolve):
+
+    - A hypothesis whose **type is a Prop application** `R a b …` headed by a
+      named symbol — a constant (`LT.lt a b` from `a < b`) OR a *local* free
+      variable (a relation from `variable (R : …)` or a binder; these are fvars,
+      not constants) — becomes a tuple in a relation named after `R` (the
+      hypothesis binder name, e.g. `h`, is *not* rendered — the relation name
+      carries the meaning). Only the data arguments are walked as atoms; proofs,
+      types, AND instance arguments (e.g. the `LT Nat` instance inside `a < b`)
+      are dropped. With ≥ 2 data args they are connected by one tuple; with
+      exactly 1, the lone atom appears with no edge; with 0, the hypothesis is
+      skipped.
+    - A **data hypothesis** (type is not a Prop, e.g. `t : Tree`) is
+      relationalized through the normal walker. An abstract hypothesis variable
+      (no definition) has no structure to descend into and renders as a single
+      atom typed by its type's head.
+    - A Prop hypothesis that is **not** a named-symbol application (e.g.
+      `∀ x, P x`, `A ∧ B`, `A → B`) is skipped; a one-line `logInfo` note reports
+      how many such hypotheses were skipped so they aren't silently missing.
+    - Each **goal** target gets the same Prop-application treatment, but its
+      relation name is prefixed `⊢ ` (so `.atomColor`/edge specs can distinguish
+      goal structure from hypotheses). A goal that is not a decomposable Prop
+      application becomes a single atom whose `type` field is `"Goal"` (so
+      `.atomColor (selector := "Goal")` works) and whose label is the
+      pretty-printed goal type.
+
+    Everything is walked into ONE shared diagram, so a hypothesis and a goal that
+    mention the same term point at the same atom.
+
+    Use `spytial_goals with [<ops>]` to attach layout operations, just like the
+    `spytial` tactic. There is no single subject type, so no `spytial_spec`
+    fallback applies; without a `with` block, no spec YAML is sent.
+
+    ```
+    example {α : Type} (R : α → α → Prop) (x y : α)
+        (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+      spytial_goals
+      exact hsymm x y h
+    ```
+
+    The diagram shows relation `R` with the tuple `x → y` (from `h`), the goal
+    relation `⊢ R` with the tuple `y → x`, and a note that `hsymm` (a `∀`) was
+    skipped.
+
+    **Experimental.** This tactic is new and its output shape may change. Stretch
+    goals from the issue — tactic diff (before/after a step), dependency
+    highlighting, and interactive selection — are not yet implemented. -/
+syntax (name := spytialGoalsTactic) "spytial_goals" (" with " term)? : tactic
+
+open Tactic in
+@[tactic spytialGoalsTactic]
+def elabSpytialGoalsTactic : Tactic := fun stx => do
+  let specOpt := stx[1]
+  -- Spec partitioning mirrors the other tactics: `.notationLabel` ops configure
+  -- the walk (collapsed types); the rest become YAML. There is no subject type,
+  -- so no type-attached spec fallback — without `with`, no YAML.
+  let (cfg, yaml) ← if specOpt.isNone then
+      pure ({ : WalkConfig }, none)
+    else do
+      let specTerm := specOpt[1]!
+      let spec ← evalSpytialSpec specTerm
+      pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+            some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+
+  -- `getGoals` lives in `TacticM`; snapshot the goal list here, then walk it all
+  -- inside one shared `StateT WalkState MetaM` so the diagram is shared.
+  let goals ← getGoals
+  let walk : StateT WalkState MetaM Nat := do
+    let mut skipped : Nat := 0
+    for mvarId in goals do
+      skipped ← mvarId.withContext do
+        let mut skipped := skipped
+        -- Hypotheses (skip implementation-detail decls).
+        for decl in ← getLCtx do
+          if decl.isImplementationDetail then continue
+          let hypTy ← instantiateMVars decl.type
+          if ← Meta.isProp hypTy then
+            -- Prop hypothesis: relation if it is a named-symbol (const/fvar)
+            -- application, else skip and count it for the note.
+            let decomposed ← walkPropApp cfg "" hypTy
+            unless decomposed do
+              skipped := skipped + 1
+          else
+            -- Data hypothesis: relationalize its fvar structurally.
+            let fv ← instantiateMVars decl.toExpr
+            let _ ← walkExpr cfg fv
+        -- Goal target.
+        let goalTy ← instantiateMVars (← mvarId.getType)
+        let decomposed ← walkPropApp cfg "⊢ " goalTy
+        unless decomposed do
+          -- Not a decomposable Prop application: a single `Goal`-typed atom.
+          let label ← ppLabel goalTy
+          modify fun s =>
+            let (atomId, s) := s.freshId
+            s.addAtom { id := atomId, type := "Goal", label := label }
+        return skipped
+    return skipped
+
+  let (skipped, state) ← walk.run {}
+  let di := state.toDataInstance
+
+  if skipped > 0 then
+    logInfo m!"spytial_goals: skipped {skipped} hypothesis(es) that are not \
+      relation applications (e.g. `∀`, `∧`, `→`)."
+
+  let props : Json := Json.mkObj <|
+    [("dataInstance", toJson di)] ++
+    match yaml with
+    | some s => [("cndSpec", toJson s)]
+    | none => []
+
+  savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
+
+/-- `spytial_goals_datum` prints the JSON data instance for the current proof
+    state (the debugging counterpart of `spytial_goals`, mirroring the `.datum`
+    debug commands). It walks the same hypotheses and goals but `logInfo`s the
+    JSON instead of opening the widget, so the structure is visible in the build
+    log.
+
+    The keyword is `spytial_goals_datum` (underscore), not `spytial_goals.datum`:
+    in tactic position a trailing `.datum` lexes as a field projection rather than
+    part of the keyword, so the dotted form does not parse. The `#spytial.datum`
+    *command* can use a dot because `#`-prefixed command tokens are lexed whole. -/
+syntax (name := spytialGoalsDatumTactic) "spytial_goals_datum" : tactic
+
+open Tactic in
+@[tactic spytialGoalsDatumTactic]
+def elabSpytialGoalsDatumTactic : Tactic := fun _stx => do
+  let goals ← getGoals
+  let walk : StateT WalkState MetaM Unit := do
+    for mvarId in goals do
+      mvarId.withContext do
+        for decl in ← getLCtx do
+          if decl.isImplementationDetail then continue
+          let hypTy ← instantiateMVars decl.type
+          if ← Meta.isProp hypTy then
+            let _ ← walkPropApp ({ : WalkConfig }) "" hypTy
+          else
+            let fv ← instantiateMVars decl.toExpr
+            let _ ← walkExpr ({ : WalkConfig }) fv
+        let goalTy ← instantiateMVars (← mvarId.getType)
+        let decomposed ← walkPropApp ({ : WalkConfig }) "⊢ " goalTy
+        unless decomposed do
+          let label ← ppLabel goalTy
+          modify fun s =>
+            let (atomId, s) := s.freshId
+            s.addAtom { id := atomId, type := "Goal", label := label }
+  let (_, state) ← walk.run {}
+  let json := toJson state.toDataInstance
+  logInfo m!"{json.pretty}"
+
 end SpytialLean

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -72,13 +72,18 @@ def elabSpytialCmd : CommandElab := fun
       let e ← Term.elabTerm t none
       Term.synthesizeSyntheticMVarsNoPostponing
       let e ← instantiateMVars e
-      let di ← relationalize e
-      -- Determine spec: explicit `with [...]` > type attribute > none
-      let yaml ← match spec? with
+      -- Evaluate the spec FIRST: relationalizer-side ops (`.notationLabel`) must
+      -- influence the walk, so they are partitioned into `WalkConfig.collapseTypes`
+      -- while the remaining (widget) ops become the YAML.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupTypeSpec e
+          pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => do
+          -- Type-attached specs are stored as YAML and cannot carry `.notationLabel`.
+          pure ({ : WalkConfig }, ← lookupTypeSpec e)
+      let di ← relationalize e cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -117,6 +122,12 @@ def elabSpytialSpecCmd : CommandElab := fun
       throwError s!"unknown declaration '{declName}'"
     let yamlStr ← liftTermElabM do
       let spec ← evalSpytialSpec specTerm
+      -- Type-attached specs are stored as YAML in the environment extension, so
+      -- relationalizer-side ops (`.notationLabel`) cannot round-trip through them
+      -- (PLAN.md #24). Rather than silently drop them, reject them clearly.
+      unless spec.collapseTypes.isEmpty do
+        throwError "'.notationLabel' is not supported in type-attached specs yet; \
+          use it in a `with [...]` block"
       return SpytialSpec.toYaml spec
     liftCoreM <| setSpytialSpec declName yamlStr
   | stx => throwError "Unexpected syntax {stx}."
@@ -153,7 +164,12 @@ unsafe def elabSpytialRelationalizerCmd : CommandElab := fun
 /-! ## Debugging commands -/
 
 /-- `#spytial.spec <term> with [<ops>]` prints the generated YAML spec.
-    Useful for debugging whether the spec is what you expect. -/
+    Useful for debugging whether the spec is what you expect.
+
+    Relationalizer-side ops (e.g. `.notationLabel`) are NOT YAML — they configure
+    the walk, not the widget — so they are stripped before printing (just as the
+    `#spytial` elaborator strips them before sending YAML to spytial-core). Their
+    effect shows up in `#spytial.datum`/the diagram, not here. -/
 syntax (name := spytialSpecDebug) "#spytial.spec " term " with " term : command
 
 @[command_elab spytialSpecDebug]
@@ -161,7 +177,7 @@ def elabSpytialSpecDebug : CommandElab := fun
   | `(#spytial.spec $_t:term with $specTerm:term) => do
     let yamlStr ← liftTermElabM do
       let spec ← evalSpytialSpec specTerm
-      return SpytialSpec.toYaml spec
+      return SpytialSpec.toYaml spec.withoutRelationalizerOps
     logInfo m!"{yamlStr}"
   | stx => throwError "Unexpected syntax {stx}."
 
@@ -198,12 +214,15 @@ def elabSpytialProofCmd : CommandElab := fun
       let e ← Term.elabTerm t none
       Term.synthesizeSyntheticMVarsNoPostponing
       let e ← instantiateMVars e
-      let di ← relationalize e { filterProofs := false }
-      let yaml ← match spec? with
+      -- Evaluate the spec first so `.notationLabel` ops can configure the walk
+      -- (collapsed types) while proof mode keeps `filterProofs := false`.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupTypeSpec e
+          pure ({ filterProofs := false, collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => pure ({ filterProofs := false : WalkConfig }, ← lookupTypeSpec e)
+      let di ← relationalize e cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -259,10 +278,11 @@ private def lookupSpecForType (ty : Expr) : MetaM (Option String) := do
 
 /-- Enumerate all inhabitants of `ty` (via `tryEnumerateDomain`) and walk them
     into a single shared `JsonDataInstance`. Throws a clear error naming the type
-    if it is not enumerable. -/
-private def enumerateType (ty : Expr) : MetaM JsonDataInstance := do
+    if it is not enumerable. `cfg` forwards walker configuration (e.g. the
+    `.notationLabel` collapse set) to `relationalizeAll`. -/
+private def enumerateType (ty : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do
   match ← tryEnumerateDomain ty with
-  | some elems => relationalizeAll (elems.map (·.2))
+  | some elems => relationalizeAll (elems.map (·.2)) cfg
   | none =>
     throwError "#spytial.enumerate cannot enumerate '{ty}'. Enumerable types are: \
       Bool, Fin n (n ≤ 20), and inductive types whose constructors all take no arguments."
@@ -292,13 +312,15 @@ def elabSpytialEnumerateCmd : CommandElab := fun
   | stx@`(#spytial.enumerate $t:term $[with $spec?]?) => do
     let (dataInstance, specYaml) ← liftTermElabM do
       let ty ← elabAsType t
-      let di ← enumerateType ty
-      -- Determine spec: explicit `with [...]` > spec attached to the type > none
-      let yaml ← match spec? with
+      -- Evaluate the spec first so `.notationLabel` ops configure the enumeration
+      -- walk (collapsed types) while the remaining ops become the YAML.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupSpecForType ty
+          pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => pure ({ : WalkConfig }, ← lookupSpecForType ty)
+      let di ← enumerateType ty cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -354,13 +376,15 @@ def elabSpytialTactic : Tactic := fun stx => do
     let e ← Term.elabTerm t none
     Term.synthesizeSyntheticMVarsNoPostponing
     let e ← instantiateMVars e
-    let di ← relationalize e
-    let yaml ← if specOpt.isNone then
-        lookupTypeSpec e
-      else
+    -- Evaluate the spec first so `.notationLabel` ops configure the walk.
+    let (cfg, yaml) ← if specOpt.isNone then
+        pure ({ : WalkConfig }, ← lookupTypeSpec e)
+      else do
         let specTerm := specOpt[1]!
         let spec ← evalSpytialSpec specTerm
-        pure (some (SpytialSpec.toYaml spec))
+        pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+              some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+    let di ← relationalize e cfg
 
     let props : Json := Json.mkObj <|
       [("dataInstance", toJson di)] ++
@@ -385,13 +409,16 @@ def elabSpytialProofTactic : Tactic := fun stx => do
     let e ← Term.elabTerm t none
     Term.synthesizeSyntheticMVarsNoPostponing
     let e ← instantiateMVars e
-    let di ← relationalize e { filterProofs := false }
-    let yaml ← if specOpt.isNone then
-        lookupTypeSpec e
-      else
+    -- Evaluate the spec first so `.notationLabel` ops configure the walk;
+    -- proof mode keeps `filterProofs := false`.
+    let (cfg, yaml) ← if specOpt.isNone then
+        pure ({ filterProofs := false : WalkConfig }, ← lookupTypeSpec e)
+      else do
         let specTerm := specOpt[1]!
         let spec ← evalSpytialSpec specTerm
-        pure (some (SpytialSpec.toYaml spec))
+        pure ({ filterProofs := false, collapseTypes := spec.collapseTypes : WalkConfig },
+              some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+    let di ← relationalize e cfg
 
     let props : Json := Json.mkObj <|
       [("dataInstance", toJson di)] ++

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -234,6 +234,101 @@ def elabSpytialProofDatumDebug : CommandElab := fun
     logInfo m!"{json.pretty}"
   | stx => throwError "Unexpected syntax {stx}."
 
+/-! ## Enumeration -/
+
+/-- Elaborate `t` and check that it denotes a *type* (its inferred type is a
+    sort). Returns the elaborated type expression. Errors clearly if the user
+    passed a value instead of a type. -/
+private def elabAsType (t : Syntax) : TermElabM Expr := do
+  let e ← Term.elabTerm t none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let e ← instantiateMVars e
+  let eTy ← Meta.inferType e
+  unless (← Meta.whnf eTy).isSort do
+    throwError "#spytial.enumerate expects a type, but '{e}' is a value of type '{eTy}'. \
+      Pass a type such as `Bool`, `Fin 5`, or a zero-arity enum inductive."
+  return e
+
+/-- Look up a Spytial spec attached to a type *by the type itself* (not by the
+    type of a value). Used by `#spytial.enumerate`, whose argument is already a
+    type expression. -/
+private def lookupSpecForType (ty : Expr) : MetaM (Option String) := do
+  match (← whnf ty).getAppFn with
+  | .const n _ => return getSpytialSpec? (← getEnv) n
+  | _ => return none
+
+/-- Enumerate all inhabitants of `ty` (via `tryEnumerateDomain`) and walk them
+    into a single shared `JsonDataInstance`. Throws a clear error naming the type
+    if it is not enumerable. -/
+private def enumerateType (ty : Expr) : MetaM JsonDataInstance := do
+  match ← tryEnumerateDomain ty with
+  | some elems => relationalizeAll (elems.map (·.2))
+  | none =>
+    throwError "#spytial.enumerate cannot enumerate '{ty}'. Enumerable types are: \
+      Bool, Fin n (n ≤ 20), and inductive types whose constructors all take no arguments."
+
+/-- `#spytial.enumerate <Type>` enumerates ALL inhabitants of a finite type and
+    renders the entire population in a single spatial diagram.
+
+    Enumerable types are `Bool`, `Fin n` (for `n ≤ 20`), and inductive types
+    whose constructors all take no arguments. Every inhabitant is walked into one
+    shared diagram, so references between them (e.g. a function field pointing at
+    an enumerated element) unify.
+
+    ```
+    inductive Color | red | green | blue
+    #spytial.enumerate Color
+    #spytial.enumerate Bool
+    #spytial.enumerate (Fin 5)
+    ```
+
+    Use `with [...]` to specify layout operations. If the enumerated type has an
+    attached spec (via `spytial_spec`), it is used as the default.
+-/
+syntax (name := spytialEnumerateCmd) "#spytial.enumerate " term (" with " term)? : command
+
+@[command_elab spytialEnumerateCmd]
+def elabSpytialEnumerateCmd : CommandElab := fun
+  | stx@`(#spytial.enumerate $t:term $[with $spec?]?) => do
+    let (dataInstance, specYaml) ← liftTermElabM do
+      let ty ← elabAsType t
+      let di ← enumerateType ty
+      -- Determine spec: explicit `with [...]` > spec attached to the type > none
+      let yaml ← match spec? with
+        | some specTerm => do
+          let spec ← evalSpytialSpec specTerm
+          pure (some (SpytialSpec.toYaml spec))
+        | none => lookupSpecForType ty
+      return (di, yaml)
+
+    let props : Json := Json.mkObj <|
+      [("dataInstance", toJson dataInstance)] ++
+      match specYaml with
+      | some s => [("cndSpec", toJson s)]
+      | none => []
+
+    liftCoreM <| savePanelWidgetInfo
+      SpytialWidget.javascriptHash
+      (return props)
+      stx
+
+  | stx => throwError "Unexpected syntax {stx}."
+
+/-- `#spytial.enumerate.datum <Type>` prints the JSON data instance produced by
+    enumerating all inhabitants of a finite type. The debugging counterpart of
+    `#spytial.enumerate`, mirroring `#spytial.datum`. -/
+syntax (name := spytialEnumerateDatumDebug) "#spytial.enumerate.datum " term : command
+
+@[command_elab spytialEnumerateDatumDebug]
+def elabSpytialEnumerateDatumDebug : CommandElab := fun
+  | `(#spytial.enumerate.datum $t:term) => do
+    let dataInstance ← liftTermElabM do
+      let ty ← elabAsType t
+      enumerateType ty
+    let json := toJson dataInstance
+    logInfo m!"{json.pretty}"
+  | stx => throwError "Unexpected syntax {stx}."
+
 /-! ## spytial tactic -/
 
 open Tactic in

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -181,6 +181,30 @@ def elabSpytialSpecDebug : CommandElab := fun
     logInfo m!"{yamlStr}"
   | stx => throwError "Unexpected syntax {stx}."
 
+/-- `#spytial.typespec <term>` prints the YAML spec that `lookupTypeSpec` resolves
+    for the term's head type (via `spytial_spec`), or `none` if no spec applies.
+
+    This is the spec lookup itself — the same lookup `#spytial` performs when no
+    explicit `with [...]` block is given. For structures and type classes (which
+    *are* structures in Lean 4) it walks the parent chain and composes specs
+    root-first, so a child inherits a parent's `spytial_spec` (PLAN.md #2). Use it
+    to confirm that a parent spec is found and merged for a child value — the
+    YAML it prints contains the lines from every spec in the chain. -/
+syntax (name := spytialTypeSpecDebug) "#spytial.typespec " term : command
+
+@[command_elab spytialTypeSpecDebug]
+def elabSpytialTypeSpecDebug : CommandElab := fun
+  | `(#spytial.typespec $t:term) => do
+    let result ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      lookupTypeSpec e
+    match result with
+    | some yaml => logInfo m!"{yaml}"
+    | none      => logInfo m!"none"
+  | stx => throwError "Unexpected syntax {stx}."
+
 /-- `#spytial.datum <term>` prints the generated JSON data instance.
     Shows what atoms and relations the relationalizer produces. -/
 syntax (name := spytialDatumDebug) "#spytial.datum " term : command

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -628,10 +628,11 @@ def elabSpytialGoalsTactic : Tactic := fun stx => do
         let decomposed ← walkPropApp cfg "⊢ " goalTy
         unless decomposed do
           -- Not a decomposable Prop application: a single `Goal`-typed atom.
+          -- Allocate through `freshAtomId` so it respects `maxAtoms` like every
+          -- other atom-producing path.
           let label ← ppLabel goalTy
-          modify fun s =>
-            let (atomId, s) := s.freshId
-            s.addAtom { id := atomId, type := "Goal", label := label }
+          let atomId ← freshAtomId cfg
+          modify fun s => s.addAtom { id := atomId, type := "Goal", label := label }
         return skipped
     return skipped
 
@@ -681,9 +682,8 @@ def elabSpytialGoalsDatumTactic : Tactic := fun _stx => do
         let decomposed ← walkPropApp ({ : WalkConfig }) "⊢ " goalTy
         unless decomposed do
           let label ← ppLabel goalTy
-          modify fun s =>
-            let (atomId, s) := s.freshId
-            s.addAtom { id := atomId, type := "Goal", label := label }
+          let atomId ← freshAtomId ({ : WalkConfig })
+          modify fun s => s.addAtom { id := atomId, type := "Goal", label := label }
   let (_, state) ← walk.run {}
   let json := toJson state.toDataInstance
   logInfo m!"{json.pretty}"

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -33,6 +33,11 @@ def WalkState.addTuple (s : WalkState) (relName : String) (types : Array String)
 def WalkState.markSeen (s : WalkState) (hash : UInt64) (atomId : String) : WalkState :=
   { s with seen := s.seen.insert hash atomId }
 
+/-- Mark an already-emitted atom as DAG-shared (visited from more than one
+    parent). Finds the atom by id in `atoms` and sets its `shared` flag. -/
+def WalkState.markShared (s : WalkState) (atomId : String) : WalkState :=
+  { s with atoms := s.atoms.map fun a => if a.id == atomId then { a with shared := true } else a }
+
 /-- Convert accumulated state to a JsonDataInstance. -/
 def WalkState.toDataInstance (s : WalkState) : JsonDataInstance :=
   let relations := s.relations.toArray.map fun (name, types, tuples) =>
@@ -131,10 +136,13 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
   -- WHNF reduce to expose constructors
   let e ← Meta.whnf eOrig
 
-  -- Check for cycles
+  -- Check for cycles / DAG sharing
   let hash := e.hash
   let s ← get
   if let some existingId := s.seen[hash]? then
+    -- Revisiting a structurally identical subterm: mark the already-emitted
+    -- atom as shared so downstream consumers can style it distinctly.
+    modify fun s => s.markShared existingId
     return existingId
 
   let ty ← Meta.inferType e
@@ -187,9 +195,9 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     return atomId
 
   | _ => do
-    -- Try to get the type name
+    -- Try to get the type name (keep the whnf'd type around for index reading)
+    let tyWhnf ← Meta.whnf ty
     let typeName ← do
-      let tyWhnf ← Meta.whnf ty
       match tyWhnf.getAppFn with
       | .const n _ => pure (shortName n)
       | _ => pure (← ppLabel ty)
@@ -198,10 +206,51 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     match e.getAppFn with
     | .const fnName _ => do
       let env ← getEnv
+      -- Quotient values: `Quot.mk r repr` is kernel-primitive (`.quotInfo`,
+      -- not `.ctorInfo`), so it misses the constructor check below and would
+      -- otherwise become an opaque leaf. We special-case it: emit a `⟦·⟧`
+      -- atom and walk the representative (the last argument) via a `repr` edge.
+      -- `Quotient.mk` / `Quotient.mk'` usually reduce to `Quot.mk` under whnf,
+      -- but we match those const heads too in case whnf stopped early.
+      if fnName == ``Quot.mk || fnName == ``Quotient.mk || fnName == ``Quotient.mk' then
+        let args := e.getAppArgs
+        modify fun s => s.addAtom { id := atomId, type := typeName, label := "⟦·⟧" }
+        -- A full application has ≥ 3 args; the representative is the last one.
+        if args.size ≥ 3 then
+          let repr := args[args.size - 1]!
+          let childId ← walkExpr cfg repr
+          modify fun s => s.addTuple "repr" #[typeName, typeName]
+            { atoms := #[atomId, childId], types := #[typeName, typeName] }
+        return atomId
       -- Is it a constructor?
-      if let some (.ctorInfo ci) := env.find? fnName then
+      else if let some (.ctorInfo ci) := env.find? fnName then
         let ctorShortName := shortName fnName
-        modify fun s => s.addAtom { id := atomId, type := typeName, label := ctorShortName }
+        -- Indexed inductive families: surface the index expressions in the
+        -- label (e.g. `cons : Vec 2`) so atoms at different indices are
+        -- distinguishable. The `type` field stays the head const short name —
+        -- selectors depend on it, so only the *label* changes, and only when
+        -- the family actually has indices.
+        let label ← do
+          let indVal? := env.find? ci.induct
+          match indVal? with
+          | some (.inductInfo iv) =>
+            if iv.numIndices > 0 then
+              -- The value's type is `T params… indices…`; read the trailing
+              -- `numIndices` arguments off the (already whnf'd) type.
+              let tyArgs := tyWhnf.getAppArgs
+              let indexExprs := tyArgs.extract (tyArgs.size - iv.numIndices) tyArgs.size
+              let mut indexStrs : Array String := #[]
+              for ix in indexExprs do
+                -- Reduce the index to a normal form so e.g. `n + 1` with a
+                -- literal `n` prints as `2`, not `1 + 1`.
+                let ixR ← Meta.whnf ix
+                indexStrs := indexStrs.push (← ppLabel ixR)
+              let joined := String.intercalate " " indexStrs.toList
+              pure s!"{ctorShortName} : {typeName} {joined}"
+            else
+              pure ctorShortName
+          | _ => pure ctorShortName
+        modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
         -- Extract binder names from the constructor type (skip type params)
         let mut binderNames : Array Name := #[]
         let mut ctorTy := ci.type

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -128,6 +128,58 @@ def tryEnumerateDomain (ty : Expr) : MetaM (Option (Array (String × Expr))) := 
     else return none
   | _ => return none
 
+/-- Weak-head normalize a function body just enough to expose its top-level
+    structure (`ite` / `dite` / matcher / `casesOn` / `letE`), WITHOUT unfolding
+    definitions (so notation like `n * 2` survives) and WITHOUT zeta-reducing
+    `let`s (so `letE` stays visible to surface as a `let` node). -/
+def whnfBody (e : Expr) : MetaM Expr :=
+  Meta.withConfig (fun c => { c with zeta := false, zetaDelta := false })
+    (Meta.whnfCore e)
+
+/-- Short name of a type's head constant (whnf'd), or its pretty-printed form
+    if the head is not a constant. Used to fill the `type` field of atoms. -/
+def typeShortName (ty : Expr) : MetaM String := do
+  match (← Meta.whnf ty).getAppFn with
+  | .const n _ => pure (shortName n)
+  | _ => pure (← ppLabel ty)
+
+/-- The data needed to decompose a `T.casesOn` application: the inductive's
+    parameter / index counts and its constructors in declaration order. -/
+structure CasesOnInfo where
+  numParams : Nat
+  numIndices : Nat
+  ctors : Array Name
+
+/-- Emit a single leaf atom for an already-reduced expression and return its id.
+
+    Pretty-prints `e` *as given* (no further reduction). The structural walker
+    uses this for leaves of a function body so that arithmetic on the bound
+    variable keeps its surface form (`n * 2`) instead of being unfolded by the
+    full `whnf` that `walkExpr` would apply at its entry. -/
+def emitLeaf (e : Expr) : StateT WalkState MetaM String := do
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  let typeName ← typeShortName (← Meta.inferType e)
+  let label ← ppLabel e
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
+  return atomId
+
+/-- If `fnName` is `T.casesOn` for an inductive `T`, return the `CasesOnInfo`
+    describing `T`; otherwise `none`. The name must be `Name.str indName "casesOn"`
+    where `indName` resolves to an `InductiveVal`. -/
+def isCasesOnApp? (fnName : Name) : MetaM (Option CasesOnInfo) := do
+  match fnName with
+  | .str indName "casesOn" =>
+    match (← getEnv).find? indName with
+    | some (.inductInfo iv) =>
+      return some { numParams := iv.numParams, numIndices := iv.numIndices,
+                    ctors := iv.ctors.toArray }
+    | _ => return none
+  | _ => return none
+
+mutual
+
 /-- Walk a Lean expression and produce atoms + relations.
     Returns the atom ID assigned to this expression. -/
 partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState MetaM String := do
@@ -171,8 +223,10 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     modify fun s => s.addAtom { id := atomId, type := "String", label := s!"\"{str}\"" }
     return atomId
 
-  -- Lambda — try to enumerate finite domain, otherwise labeled node
-  | .lam binderName binderType _body _bi => do
+  -- Lambda — try to enumerate finite domain (extensional view, what it
+  -- computes); otherwise decompose the body structurally (intensional view,
+  -- how it is defined) instead of leaving an opaque leaf.
+  | .lam binderName binderType body bi => do
     let typeName ← do
       let tyWhnf ← Meta.whnf ty
       match tyWhnf.getAppFn with
@@ -186,12 +240,24 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     let domainElems ← tryEnumerateDomain binderType
     match domainElems with
     | some elems =>
+      -- Extensional view: enumerate input→output edges. This is the default
+      -- for enumerable domains and its output shape must not change.
       for (elemLabel, elemExpr) in elems do
         let result ← Meta.whnf (Expr.app e elemExpr)
         let childId ← walkExpr cfg result
         modify fun s => s.addTuple elemLabel #[typeName, typeName]
           { atoms := #[atomId, childId], types := #[typeName, typeName] }
-    | none => pure ()  -- non-finite domain, just a labeled node
+    | none =>
+      -- Non-finite domain: decompose the body structurally. Enter the binder
+      -- so the bound variable is a free variable in scope, then walk the body
+      -- through the structural walker. All walking happens INSIDE the
+      -- `withLocalDecl` continuation so `ppExpr`/`inferType` on subterms
+      -- containing the fvar succeed.
+      Meta.withLocalDecl binderName bi binderType fun fv => do
+        let bodyExpr := body.instantiate1 fv
+        let childId ← walkBody cfg bodyExpr
+        modify fun s => s.addTuple "body" #[typeName, typeName]
+          { atoms := #[atomId, childId], types := #[typeName, typeName] }
     return atomId
 
   | _ => do
@@ -311,6 +377,197 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
       let label ← ppLabel e
       modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
       return atomId
+
+/-- Structurally decompose a function body (intensional view).
+
+    Used by the non-finite path of `walkExpr`'s `.lam` arm. `whnfBody`-reduces
+    the expression (weak-head, no definition unfolding, no `let` zeta) and
+    dispatches on its shape:
+
+    - `ite` / `dite` applications → a node labeled `if` with `condition` /
+      `then` / `else` edges (`dite` branches are lambdas over the decidability
+      proof; their bodies are decomposed through `walkBodyLam`).
+    - matcher auxiliaries (`f.match_n`) and `T.casesOn` applications → a node
+      labeled `match`, a `match` edge to the discriminant, and one edge per
+      branch labeled by the corresponding constructor's short name. Branch
+      bodies are lambdas over the constructor fields, decomposed via
+      `walkBodyLam` (so nested structure surfaces).
+    - `Expr.letE` → a node labeled `let` with `let_value` / `let_body` edges.
+    - nested `.lam` → recurse: multi-argument functions decompose one binder at
+      a time, the inner lambda reached via a `body` edge from `walkExpr`.
+
+    Anything else (the bound variable itself, applications of it, arithmetic on
+    it) falls back to `walkExpr`, which pretty-prints a leaf label like `n * 2`.
+    Recursive sub-parts go back through `walkBody`, so nested `if`s nest. -/
+partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
+    StateT WalkState MetaM String := do
+  -- Detect `T.casesOn` BEFORE reducing: `whnfBody` would unfold it to `T.rec`
+  -- (a different, harder-to-read shape). Matchers, `ite`/`dite`, and `letE` all
+  -- survive `whnfBody`, so they are handled after reduction below.
+  if let .const fnName _ := e.getAppFn then
+    if let some info ← isCasesOnApp? fnName then
+      return ← walkCasesOn cfg e info e.getAppArgs
+  let e ← whnfBody e
+  match e.getAppFn with
+  | .const fnName _ =>
+    let args := e.getAppArgs
+    -- if / dite: `@ite α c inst t e` / `@dite α c inst t e` — both have 5 args
+    -- with the condition at index 1, the `then` branch at 3, `else` at 4.
+    if (fnName == ``ite || fnName == ``dite) && args.size == 5 then
+      let isDite := fnName == ``dite
+      let ty ← Meta.inferType e
+      let typeName ← typeShortName ty
+      let s ← get
+      let (atomId, s) := s.freshId
+      set s
+      modify fun s => s.addAtom { id := atomId, type := typeName, label := "if" }
+      let condId ← walkBody cfg args[1]!
+      modify fun s => s.addTuple "condition" #[typeName, typeName]
+        { atoms := #[atomId, condId], types := #[typeName, typeName] }
+      -- `dite` branches abstract over the proof of `c` (resp. `¬ c`); peel that
+      -- binder off and decompose the branch body. `ite` branches are plain.
+      let thenId ← if isDite then walkBodyLam cfg args[3]! else walkBody cfg args[3]!
+      modify fun s => s.addTuple "then" #[typeName, typeName]
+        { atoms := #[atomId, thenId], types := #[typeName, typeName] }
+      let elseId ← if isDite then walkBodyLam cfg args[4]! else walkBody cfg args[4]!
+      modify fun s => s.addTuple "else" #[typeName, typeName]
+        { atoms := #[atomId, elseId], types := #[typeName, typeName] }
+      return atomId
+    -- Matcher auxiliary (`f.match_n`): a pattern match compiled to a matcher.
+    -- Layout of its application args is `[params] [motive] [discrs] [alts]`.
+    else if let some mi ← Meta.getMatcherInfo? fnName then
+      walkMatch cfg e mi args
+    -- `T.casesOn` is normally caught pre-reduction above (whnf unfolds it to
+    -- `T.rec`); this is a defensive fallback for any that slips through.
+    else if let some info ← isCasesOnApp? fnName then
+      walkCasesOn cfg e info args
+    else if (← getEnv).find? fnName matches some (.ctorInfo _) then
+      -- A constructor application (possibly mentioning the bound variable, e.g.
+      -- `x :: xs`): let `walkExpr` decompose it into its fields as usual.
+      walkExpr cfg e
+    else
+      -- Other const application on the bound variable (arithmetic, comparisons,
+      -- a recursive call): emit a leaf from the surface form. Going through
+      -- `walkExpr` here would full-`whnf` and unfold e.g. `n * 2` into
+      -- `(n.mul 1).add n`; `emitLeaf` keeps the readable `n * 2`.
+      emitLeaf e
+  | .letE declName declType value body _nonDep =>
+    -- Surface a `let`: walk the bound value, then the body with the let
+    -- variable in scope as a local decl.
+    let ty ← Meta.inferType e
+    let typeName ← typeShortName ty
+    let s ← get
+    let (atomId, s) := s.freshId
+    set s
+    modify fun s => s.addAtom { id := atomId, type := typeName, label := s!"let {declName}" }
+    let valId ← walkBody cfg value
+    modify fun s => s.addTuple "let_value" #[typeName, typeName]
+      { atoms := #[atomId, valId], types := #[typeName, typeName] }
+    Meta.withLetDecl declName declType value fun fv => do
+      let bodyExpr := body.instantiate1 fv
+      let bodyId ← walkBody cfg bodyExpr
+      modify fun s => s.addTuple "let_body" #[typeName, typeName]
+        { atoms := #[atomId, bodyId], types := #[typeName, typeName] }
+    return atomId
+  | .lam .. =>
+    -- Nested lambda (multi-argument function). Hand back to `walkExpr`, whose
+    -- `.lam` arm emits the lambda atom and recurses into its body via a `body`
+    -- edge — so each binder becomes its own layer.
+    walkExpr cfg e
+  | .lit _ =>
+    -- A bare literal: `walkExpr` already renders these cleanly (and `whnf` is
+    -- harmless on literals).
+    walkExpr cfg e
+  | _ =>
+    -- Bound variable, projection, or any other non-application head: emit a
+    -- leaf from the surface form (e.g. the binder name `n`, or `n.fst`).
+    emitLeaf e
+
+/-- Decompose a branch lambda: peel its binders (constructor fields, or a
+    `dite` decidability proof), introducing a fresh local for each, then walk
+    the resulting body structurally. Used for matcher/`casesOn` alternatives and
+    `dite` branches, whose bodies are lambdas we want to see *through* rather
+    than render as `λ`-leaves. -/
+partial def walkBodyLam (cfg : WalkConfig := {}) (e : Expr) :
+    StateT WalkState MetaM String := do
+  let e ← whnfBody e
+  match e with
+  | .lam binderName binderType lamBody bi =>
+    Meta.withLocalDecl binderName bi binderType fun fv => do
+      walkBodyLam cfg (lamBody.instantiate1 fv)
+  | _ => walkBody cfg e
+
+/-- Decompose a matcher application into a `match` node: an edge `match` to the
+    walked discriminant and one edge per alternative, labeled by the matching
+    constructor's short name. `mi` is the matcher's `MatcherInfo`; `args` are the
+    full application arguments laid out as `[params] [motive] [discrs] [alts]`. -/
+partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
+    (mi : Lean.Meta.MatcherInfo) (args : Array Expr) :
+    StateT WalkState MetaM String := do
+  let ty ← Meta.inferType e
+  let typeName ← typeShortName ty
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
+  -- Discriminants sit right after the motive (one motive slot, then numDiscrs).
+  let discrStart := mi.numParams + 1
+  let altStart := discrStart + mi.numDiscrs
+  -- Walk each discriminant via the standard walker and link it with `match`.
+  let discrs := args.extract discrStart altStart
+  let mut ctorNames : Array String := #[]
+  for discr in discrs do
+    let discrId ← walkExpr cfg discr
+    modify fun s => s.addTuple "match" #[typeName, typeName]
+      { atoms := #[atomId, discrId], types := #[typeName, typeName] }
+  -- Constructor order for branch labels comes from the discriminant's
+  -- inductive (single-discriminant matches are the common case).
+  if mi.numDiscrs == 1 then
+    let dty ← Meta.inferType discrs[0]!
+    match (← Meta.whnf dty).getAppFn with
+    | .const indName _ =>
+      if let some (.inductInfo iv) := (← getEnv).find? indName then
+        ctorNames := iv.ctors.toArray.map shortName
+    | _ => pure ()
+  -- One edge per alternative; the branch body is a lambda over its ctor fields.
+  let alts := args.extract altStart args.size
+  for h : i in [:alts.size] do
+    let altId ← walkBodyLam cfg alts[i]
+    let edgeName := if h : i < ctorNames.size then ctorNames[i] else s!"case_{i}"
+    modify fun s => s.addTuple edgeName #[typeName, typeName]
+      { atoms := #[atomId, altId], types := #[typeName, typeName] }
+  return atomId
+
+/-- Decompose a `T.casesOn` application into a `match` node, analogous to
+    `walkMatch`. Args are `[params] [motive] [indices] [major] [alts]`; `info`
+    carries the inductive's `numParams` / `numIndices` and the ctor order. -/
+partial def walkCasesOn (cfg : WalkConfig := {}) (e : Expr)
+    (info : CasesOnInfo) (args : Array Expr) :
+    StateT WalkState MetaM String := do
+  let ty ← Meta.inferType e
+  let typeName ← typeShortName ty
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
+  -- Major (the scrutinee) sits after params, motive, and indices.
+  let majorPos := info.numParams + 1 + info.numIndices
+  if h : majorPos < args.size then
+    let majorId ← walkExpr cfg args[majorPos]
+    modify fun s => s.addTuple "match" #[typeName, typeName]
+      { atoms := #[atomId, majorId], types := #[typeName, typeName] }
+  -- Branches follow the major, one per constructor in declaration order.
+  let altStart := majorPos + 1
+  let alts := args.extract altStart args.size
+  let ctorNames := info.ctors.map shortName
+  for h : i in [:alts.size] do
+    let altId ← walkBodyLam cfg alts[i]
+    let edgeName := if h : i < ctorNames.size then ctorNames[i] else s!"case_{i}"
+    modify fun s => s.addTuple edgeName #[typeName, typeName]
+      { atoms := #[atomId, altId], types := #[typeName, typeName] }
+  return atomId
+
+end
 
 /-- Walk an expression and produce a complete JsonDataInstance. -/
 def relationalize (e : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -574,4 +574,20 @@ def relationalize (e : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance :
   let (_, state) ← walkExpr cfg e |>.run {}
   return state.toDataInstance
 
+/-- Walk every expression in `es` through a *single shared* `WalkState`, then
+    produce one combined `JsonDataInstance`.
+
+    Folding `walkExpr` over a single state (rather than relationalizing each
+    expression independently and merging) means the per-expr `seen` cache is
+    shared: structurally identical subterms across the whole population collapse
+    to the same atom id, so e.g. a function field pointing at an enumerated
+    element unifies with that element. Used by `#spytial.enumerate` to render all
+    inhabitants of a finite type in one diagram. -/
+def relationalizeAll (es : Array Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do
+  let walkAll : StateT WalkState MetaM Unit := do
+    for e in es do
+      let _ ← walkExpr cfg e
+  let (_, state) ← walkAll.run {}
+  return state.toDataInstance
+
 end SpytialLean

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -48,6 +48,11 @@ def WalkState.toDataInstance (s : WalkState) : JsonDataInstance :=
 structure WalkConfig where
   /-- When true, skip Prop-typed fields (data mode). When false, show them (proof mode). -/
   filterProofs : Bool := true
+  /-- Type-head short names whose values should be collapsed to a single atom
+      labeled with their surface notation, instead of being decomposed. Populated
+      from `.notationLabel` spec ops (see `SpytialSpec.collapseTypes`). E.g.
+      `["List"]` renders `[1, 2, 3]` as one atom rather than a cons chain. -/
+  collapseTypes : List String := []
 
 /-- Check if an expression is a proof or type (erased at runtime). -/
 def isProofArg (e : Expr) : MetaM Bool := do
@@ -205,8 +210,22 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
   let s := s.markSeen hash atomId
   set s
 
-  -- Check for custom relationalizer before default dispatch
+  -- Notation collapse: if this value's type-head short name was opted in via a
+  -- `.notationLabel` spec op, emit ONE atom labeled with the surface notation of
+  -- the *original* (pre-whnf) expression and stop. `eOrig` is what the delaborator
+  -- resugars (so `[1, 2, 3]` survives instead of the cons chain). This runs before
+  -- the custom-relationalizer dispatch and the main match so neither decomposes it.
   let tyWhnfForLookup ← Meta.whnf ty
+  let typeHeadShortName : Option String := match tyWhnfForLookup.getAppFn with
+    | .const n _ => some (shortName n)
+    | _ => none
+  if let some tn := typeHeadShortName then
+    if cfg.collapseTypes.contains tn then
+      let label ← ppLabel eOrig
+      modify fun s => s.addAtom { id := atomId, type := tn, label := label }
+      return atomId
+
+  -- Check for custom relationalizer before default dispatch
   if let .const typeConstName _ := tyWhnfForLookup.getAppFn then
     if let some relFn ← getSpytialRelationalizer? typeConstName then
       return ← relFn eOrig (walkExpr cfg)

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -53,6 +53,13 @@ structure WalkConfig where
       from `.notationLabel` spec ops (see `SpytialSpec.collapseTypes`). E.g.
       `["List"]` renders `[1, 2, 3]` as one atom rather than a cons chain. -/
   collapseTypes : List String := []
+  /-- Hard upper bound on the number of atoms a single walk may produce.
+      Relationalizing a very large term (a long `List`, a deeply unfolded proof)
+      can generate thousands of atoms, which hangs the widget's layout step and
+      is rarely legible anyway. When the count would exceed this limit the walker
+      throws a clear error instead of running away. Default 5000 is far above any
+      term that renders usefully; raise it deliberately if you really need to. -/
+  maxAtoms : Nat := 5000
 
 /-- Check if an expression is a proof or type (erased at runtime). -/
 def isProofArg (e : Expr) : MetaM Bool := do
@@ -155,16 +162,33 @@ structure CasesOnInfo where
   numIndices : Nat
   ctors : Array Name
 
+/-- Allocate a fresh atom id, enforcing `cfg.maxAtoms`.
+
+    Every atom-producing path runs through one of the `freshId` call sites, so
+    routing them all through this helper makes `maxAtoms` a hard cap on the total
+    atom count regardless of which walker (value, function body, matcher, …)
+    produced them. When the next id would push the count over the limit it throws
+    an actionable error instead of building a runaway diagram. The error text is
+    deterministic (it does not depend on hash ordering). -/
+def freshAtomId (cfg : WalkConfig) : StateT WalkState MetaM String := do
+  let s ← get
+  let (atomId, s) := s.freshId
+  if s.nextId > cfg.maxAtoms then
+    throwError "spytial: relationalize produced over {cfg.maxAtoms} atoms \
+      (the WalkConfig.maxAtoms limit was hit); the term is too large to \
+      visualize usefully. Increase the limit via WalkConfig.maxAtoms, or \
+      visualize a smaller sub-term."
+  set s
+  return atomId
+
 /-- Emit a single leaf atom for an already-reduced expression and return its id.
 
     Pretty-prints `e` *as given* (no further reduction). The structural walker
     uses this for leaves of a function body so that arithmetic on the bound
     variable keeps its surface form (`n * 2`) instead of being unfolded by the
     full `whnf` that `walkExpr` would apply at its entry. -/
-def emitLeaf (e : Expr) : StateT WalkState MetaM String := do
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+def emitLeaf (cfg : WalkConfig := {}) (e : Expr) : StateT WalkState MetaM String := do
+  let atomId ← freshAtomId cfg
   let typeName ← typeShortName (← Meta.inferType e)
   let label ← ppLabel e
   modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
@@ -204,11 +228,12 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
 
   let ty ← Meta.inferType e
 
-  -- Allocate a fresh ID and mark as seen immediately (before recursing)
-  let s ← get
-  let (atomId, s) := s.freshId
-  let s := s.markSeen hash atomId
-  set s
+  -- Allocate a fresh ID (enforcing `maxAtoms`) and mark as seen immediately
+  -- (before recursing). This is the single chokepoint every `walkExpr`-entry
+  -- atom flows through; `emitLeaf` and the structural walkers below allocate
+  -- via `freshAtomId` too, so the cap bounds the total regardless of path.
+  let atomId ← freshAtomId cfg
+  modify fun s => s.markSeen hash atomId
 
   -- Notation collapse: if this value's type-head short name was opted in via a
   -- `.notationLabel` spec op, emit ONE atom labeled with the surface notation of
@@ -436,9 +461,7 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
       let isDite := fnName == ``dite
       let ty ← Meta.inferType e
       let typeName ← typeShortName ty
-      let s ← get
-      let (atomId, s) := s.freshId
-      set s
+      let atomId ← freshAtomId cfg
       modify fun s => s.addAtom { id := atomId, type := typeName, label := "if" }
       let condId ← walkBody cfg args[1]!
       modify fun s => s.addTuple "condition" #[typeName, typeName]
@@ -469,15 +492,13 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
       -- a recursive call): emit a leaf from the surface form. Going through
       -- `walkExpr` here would full-`whnf` and unfold e.g. `n * 2` into
       -- `(n.mul 1).add n`; `emitLeaf` keeps the readable `n * 2`.
-      emitLeaf e
+      emitLeaf cfg e
   | .letE declName declType value body _nonDep =>
     -- Surface a `let`: walk the bound value, then the body with the let
     -- variable in scope as a local decl.
     let ty ← Meta.inferType e
     let typeName ← typeShortName ty
-    let s ← get
-    let (atomId, s) := s.freshId
-    set s
+    let atomId ← freshAtomId cfg
     modify fun s => s.addAtom { id := atomId, type := typeName, label := s!"let {declName}" }
     let valId ← walkBody cfg value
     modify fun s => s.addTuple "let_value" #[typeName, typeName]
@@ -500,7 +521,7 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
   | _ =>
     -- Bound variable, projection, or any other non-application head: emit a
     -- leaf from the surface form (e.g. the binder name `n`, or `n.fst`).
-    emitLeaf e
+    emitLeaf cfg e
 
 /-- Decompose a branch lambda: peel its binders (constructor fields, or a
     `dite` decidability proof), introducing a fresh local for each, then walk
@@ -525,9 +546,7 @@ partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
     StateT WalkState MetaM String := do
   let ty ← Meta.inferType e
   let typeName ← typeShortName ty
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+  let atomId ← freshAtomId cfg
   modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
   -- Discriminants sit right after the motive (one motive slot, then numDiscrs).
   let discrStart := mi.numParams + 1
@@ -565,9 +584,7 @@ partial def walkCasesOn (cfg : WalkConfig := {}) (e : Expr)
     StateT WalkState MetaM String := do
   let ty ← Meta.inferType e
   let typeName ← typeShortName ty
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+  let atomId ← freshAtomId cfg
   modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
   -- Major (the scrutinee) sits after params, motive, and indices.
   let majorPos := info.numParams + 1 + info.numIndices

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -559,14 +559,18 @@ partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
     modify fun s => s.addTuple "match" #[typeName, typeName]
       { atoms := #[atomId, discrId], types := #[typeName, typeName] }
   -- Constructor order for branch labels comes from the discriminant's
-  -- inductive (single-discriminant matches are the common case).
+  -- inductive (single-discriminant matches are the common case). Guard on the
+  -- actual array: an under-applied matcher reached as a function body can leave
+  -- `discrs` empty even when `numDiscrs == 1`, and indexing would panic — the
+  -- branch loop already falls back to `case_{i}` labels when `ctorNames` is empty.
   if mi.numDiscrs == 1 then
-    let dty ← Meta.inferType discrs[0]!
-    match (← Meta.whnf dty).getAppFn with
-    | .const indName _ =>
-      if let some (.inductInfo iv) := (← getEnv).find? indName then
-        ctorNames := iv.ctors.toArray.map shortName
-    | _ => pure ()
+    if let some discr0 := discrs[0]? then
+      let dty ← Meta.inferType discr0
+      match (← Meta.whnf dty).getAppFn with
+      | .const indName _ =>
+        if let some (.inductInfo iv) := (← getEnv).find? indName then
+          ctorNames := iv.ctors.toArray.map shortName
+      | _ => pure ()
   -- One edge per alternative; the branch body is a lambda over its ctor fields.
   let alts := args.extract altStart args.size
   for h : i in [:alts.size] do

--- a/SpytialLean/Spec.lean
+++ b/SpytialLean/Spec.lean
@@ -44,6 +44,8 @@ inductive SpytialOp where
   | inferredEdge (name : String) (selector : String)
       (color : String := "#000000") (style : EdgeStyle := .solid)
   | flag (name : String)
+  -- Relationalizer-side ops (NOT widget directives, NOT constraints; see below)
+  | notationLabel (selector : String)
   deriving Repr, Inhabited
 
 /-- A list of Spytial operations forming a complete layout specification. -/
@@ -135,16 +137,54 @@ private def directiveToYaml : SpytialOp → String
     s!"  - size: \{selector: \"{sel}\", width: {w}, height: {h}}"
   | _ => ""
 
-/-- Convert a `SpytialSpec` to a YAML string consumable by `parseLayoutSpec`. -/
+/-- Convert a `SpytialSpec` to a YAML string consumable by `parseLayoutSpec`.
+
+    Relationalizer-side ops (e.g. `.notationLabel`) are not widget directives and
+    are not constraints; their `*ToYaml` arms return `""`. Those empty strings are
+    filtered out before joining, so a relationalizer-only op (or any unhandled op
+    reaching a no-match arm) cannot inject a blank YAML list entry. Such ops should
+    be stripped via `SpytialSpec.withoutRelationalizerOps` before calling this; the
+    filter is a defensive backstop only. -/
 def SpytialSpec.toYaml (spec : SpytialSpec) : String :=
   let constraints := spec.filter SpytialOp.isConstraint
   let directives := spec.filter (! SpytialOp.isConstraint ·)
   let parts : List String := []
   let parts := if constraints.isEmpty then parts else
-    parts ++ ["constraints:"] ++ constraints.map constraintToYaml
+    parts ++ ["constraints:"] ++ (constraints.map constraintToYaml).filter (· != "")
   let parts := if directives.isEmpty then parts else
-    parts ++ ["directives:"] ++ directives.map directiveToYaml
+    parts ++ ["directives:"] ++ (directives.map directiveToYaml).filter (· != "")
   "\n".intercalate parts
+
+/-! ## Relationalizer-side ops
+
+Some ops configure the *relationalizer* (how Lean terms are walked into atoms and
+relations) rather than the *widget* (how the resulting data instance is laid out).
+`.notationLabel` is the first such op: it tells the walker to collapse values of a
+given type to a single atom labeled with their surface notation. These ops are
+neither constraints nor directives — they must never reach the YAML, which is what
+spytial-core's `parseLayoutSpec` consumes. The command elaborators partition them
+out of the spec (`collapseTypes` feeds `WalkConfig`; `withoutRelationalizerOps`
+yields the remainder for `toYaml`). -/
+
+/-- Is this a relationalizer-side op (configures the walk, not the widget)? -/
+def SpytialOp.isRelationalizerOp : SpytialOp → Bool
+  | .notationLabel .. => true
+  | _ => false
+
+/-- The selectors of all `.notationLabel` ops in `spec` — type-head short names
+    whose values should be collapsed to a single notation-labeled atom. These
+    configure the *relationalizer* (fed into `WalkConfig.collapseTypes`), not the
+    widget; they never appear in the YAML. -/
+def SpytialSpec.collapseTypes (spec : SpytialSpec) : List String :=
+  spec.filterMap fun
+    | .notationLabel sel => some sel
+    | _ => none
+
+/-- Drop all relationalizer-side ops (e.g. `.notationLabel`) from `spec`, leaving
+    only the constraint/directive ops that belong in the YAML. The elaborators call
+    this before `toYaml` so relationalizer-only ops never reach spytial-core. -/
+def SpytialSpec.withoutRelationalizerOps (spec : SpytialSpec) : SpytialSpec :=
+  spec.filter (! SpytialOp.isRelationalizerOp ·)
 
 /-- Extract constraint and directive lines from a YAML spec string.
     Returns `(constraintLines, directiveLines)`. -/

--- a/SpytialLean/Types.lean
+++ b/SpytialLean/Types.lean
@@ -4,11 +4,18 @@ namespace SpytialLean
 
 open Lean
 
-/-- A single atom (node) in the relational data instance. -/
+/-- A single atom (node) in the relational data instance.
+
+    `shared` is set when this atom is a subterm reached from more than one
+    parent (a DAG-shared node). The relationalizer deduplicates structurally
+    identical subterms by `Expr.hash`; the *second and later* visits flip this
+    flag on the already-emitted atom. spytial-core ignores the field today, so
+    it is purely informational (e.g. for distinct styling). -/
 structure JsonAtom where
   id : String
   type : String
   label : String
+  shared : Bool := false
   deriving ToJson, FromJson, Inhabited
 
 /-- A tuple in a relation — an ordered list of atom IDs with their types. -/

--- a/demos/Enumeration.lean
+++ b/demos/Enumeration.lean
@@ -1,0 +1,98 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Enumeration
+
+`#spytial.enumerate <Type>` enumerates ALL inhabitants of a finite type and
+renders the entire population in a single spatial diagram.
+
+A type is enumerable when `tryEnumerateDomain` can list its elements:
+
+* `Bool` — `false`, `true`,
+* `Fin n` for `n ≤ 20` — `0 … n-1`,
+* an inductive type whose constructors *all* take no arguments (a plain enum).
+
+There is deliberately **no `Fintype` support**: that lives in Mathlib, and the
+core library and default demos stay Mathlib-free. Non-enumerable types get a
+clear error naming what is supported (see the failing case at the bottom).
+
+Every inhabitant is walked into ONE shared diagram, so structurally identical
+subterms across the population unify (the relationalizer's `seen` cache is
+shared across the whole enumeration).
+-/
+
+/-! ## A custom enum -/
+
+/-- A three-element enumeration. All constructors take no arguments, so the type
+    is enumerable. -/
+inductive Three where
+  | a | b | c
+  deriving Repr
+
+-- Renders three atoms labeled `a`, `b`, `c` in a single diagram.
+#spytial.enumerate Three
+
+-- Inspect the JSON: exactly three atoms, no relations.
+#spytial.enumerate.datum Three
+
+/-! ## Built-in finite types -/
+
+-- `Bool` enumerates to `false`, `true`.
+#spytial.enumerate Bool
+
+-- `Fin 5` enumerates to `0, 1, 2, 3, 4`.
+#spytial.enumerate (Fin 5)
+
+#spytial.enumerate.datum Bool
+#spytial.enumerate.datum (Fin 5)
+
+/-! ## Enumerating a mapping — `#spytial f` already does this
+
+The issue's motivating example is a function on a finite domain. A natural ask
+is a `#spytial.map f` command that draws the function's graph. It is
+*unnecessary*: `#spytial f` ALREADY enumerates the mapping. When the
+relationalizer reaches a `λ` whose domain is enumerable, it takes the
+extensional view — it enumerates every input and emits one input→output edge.
+So plain `#spytial f` on a `Three → Three` shows the graph `a→b`, `b→c`, `c→a`
+directly, and a separate `#spytial.map` variant would be redundant. -/
+
+/-- The issue's motivating map: a cyclic permutation of `Three`. -/
+def f : Three → Three
+  | .a => .b
+  | .b => .c
+  | .c => .a
+
+-- No `#spytial.map` needed: the lambda's finite domain is enumerated here,
+-- producing the mapping graph a→b, b→c, c→a.
+#spytial f
+#spytial.datum f
+
+/-! ## Spec lookup
+
+A spec attached to the enumerated type (via `spytial_spec`) is used as the
+default, just like `#spytial` looks up the spec of a value's type. An explicit
+`with [...]` overrides it. -/
+
+spytial_spec Three [
+  .atomColor (selector := "Three") (value := "#4CAF50")
+]
+
+-- Uses the spec attached to `Three`.
+#spytial.enumerate Three
+
+-- Explicit `with [...]` overrides the attached spec.
+#spytial.enumerate Three with [
+  .atomColor (selector := "Three") (value := "#2196F3")
+]
+
+/-! ## Failing case — non-enumerable type
+
+`Nat` has infinitely many inhabitants, so it is not enumerable. Uncommenting the
+line below produces:
+
+  #spytial.enumerate cannot enumerate 'Nat'. Enumerable types are: Bool,
+  Fin n (n ≤ 20), and inductive types whose constructors all take no arguments.
+-/
+
+-- #spytial.enumerate Nat -- error: not enumerable

--- a/demos/FunctionFields.lean
+++ b/demos/FunctionFields.lean
@@ -6,6 +6,32 @@ open SpytialLean
 
 Structures with function-valued fields should decompose into mapping
 graphs rather than rendering as opaque lambda blobs.
+
+## Two views of a function: extensional vs intensional
+
+The relationalizer renders a `λ` two different ways depending on its domain:
+
+* **Extensional (what it computes).** When the domain is *finite and
+  enumerable* (`Bool`, `Fin n` for `n ≤ 20`, a zero-arity enum inductive), the
+  walker enumerates every input and emits one edge per input→output pair. The
+  diagram *is* the function's graph. This is the default and its shape is fixed.
+
+* **Intensional (how it is defined).** When the domain is *not* enumerable
+  (`Nat`, `List Nat`, …), enumerating is impossible, so instead of an opaque
+  leaf the walker decomposes the function *body* structurally — an AST view.
+  Entering the binder with `withLocalDecl`, it weak-head-reduces the body
+  (without unfolding definitions or `let`s) and emits:
+
+  - `if` / `dite` → an `if` node with `condition` / `then` / `else` edges,
+  - a pattern match (matcher auxiliary or `casesOn`) → a `match` node with a
+    `match` edge to the discriminant and one edge per branch, labeled by the
+    matching constructor,
+  - `let` → a `let` node with `let_value` / `let_body` edges,
+  - nested `λ` (multi-argument functions) → a `body` edge into the next binder,
+  - anything else (the bound variable, arithmetic on it, …) → a leaf labeled
+    with the pretty-printed surface expression (`n * 2`, `n > 10`).
+
+  Nested constructs nest: the `then` branch of an `if` can itself be an `if`.
 -/
 
 /-! ## Lightweight category theory structures -/
@@ -48,17 +74,19 @@ def myFunctor : SimpleFunctor threeStruct twoStruct :=
 structure Transform where
   f : Bool → Nat
 
-
--- TODO: I wonder if we can do something better about
--- the relationalization here. Like should it be , here's the body
--- of the transform with an "if" etc etc. Like an AST kind of thing?
 def myTransform : Transform :=
   { f := fun b => if b then 42 else 0 }
 
--- `f` is a function Bool → Nat — should enumerate true→42, false→0
+-- `f` has a finite domain (`Bool`) — extensional view: enumerate true→42,
+-- false→0. The body `if b then …` is NOT decomposed structurally here, because
+-- enumeration already shows exactly what the function computes.
 #spytial myTransform
 
-/-! ## Non-finite function field (graceful fallback) -/
+/-! ## Non-finite function field — structural (AST) decomposition
+
+`Nat` is not enumerable, so `process` cannot be shown extensionally. Rather than
+the opaque lambda blob this used to render, the body is now decomposed into an
+AST: `Processor.mk` → `process` → `λ n` → `body` → leaf `n + 1`. -/
 
 structure Processor where
   process : Nat → Nat
@@ -66,5 +94,55 @@ structure Processor where
 def myProcessor : Processor :=
   { process := fun n => n + 1 }
 
--- Nat is not finite — should show a labeled node, not an opaque blob
 #spytial myProcessor
+#spytial.datum myProcessor
+
+/-! ## Structural decomposition gallery (intensional view)
+
+The functions below all have non-enumerable domains, so each is shown as the
+structure of its definition. Use `#spytial.datum` to inspect the JSON: the
+`if` / `match` / `let` nodes and their edges are visible there. -/
+
+/-- An `if`-expression body. The decidable condition `n > 10` does not block the
+    `ite` — the walker emits an `if` node with `condition` / `then` / `else`
+    edges to the leaves `n > 10`, `n * 2`, `n + 1`. -/
+def classify : Nat → Nat := fun n => if n > 10 then n * 2 else n + 1
+
+#spytial classify
+#spytial.datum classify
+
+/-- Nested `if`: the `then` branch is itself an `if`, so the diagram nests one
+    `if` node inside another's `then` edge. -/
+def bucket : Nat → Nat := fun n =>
+  if n > 100 then 3 else if n > 10 then 2 else 1
+
+#spytial bucket
+#spytial.datum bucket
+
+/-- A pattern match over `List Nat` (a non-finite inductive payload). `match`
+    compiles to a matcher auxiliary; the walker emits a `match` node, a `match`
+    edge to the discriminant `l`, and `nil` / `cons` branch edges. -/
+def headOrZero : List Nat → Nat := fun l =>
+  match l with
+  | [] => 0
+  | x :: _ => x
+
+#spytial headOrZero
+#spytial.datum headOrZero
+
+/-- A two-argument function: nested lambdas decompose one binder per layer.
+    `λ a` → `body` → `λ b` → `body` → leaf `a + b`. -/
+def add2 : Nat → Nat → Nat := fun a b => a + b
+
+#spytial add2
+#spytial.datum add2
+
+/-- A `let`-binding survives reduction (zeta is disabled), so it surfaces as a
+    `let` node with `let_value` and `let_body` edges; the body here is itself an
+    `if`, which nests under `let_body`. -/
+def stepThenBranch : Nat → Nat := fun n =>
+  let y := n + 1
+  if y > 5 then y else 0
+
+#spytial stepThenBranch
+#spytial.datum stepThenBranch

--- a/demos/IndexedFamilies.lean
+++ b/demos/IndexedFamilies.lean
@@ -1,0 +1,36 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Indexed inductive families
+
+For an indexed inductive family the *index* carries information that the
+constructor name alone does not. A length-indexed `Vec` is the canonical case:
+`Vec.nil : Vec α 0` and a `Vec.cons … : Vec α 2` are different shapes, but their
+constructor atoms would be labeled just `nil` and `cons` — indistinguishable at
+a glance.
+
+When a constructor's inductive has `numIndices > 0`, the relationalizer reads
+the trailing index expressions off the value's *type* and appends them to the
+atom label, e.g. `cons : Vec 2`, `nil : Vec 0`. Only the label changes — the
+atom `type` field stays the head constant short name (`Vec`), so selectors that
+match on `type` are unaffected.
+-/
+
+/-! ## A length-indexed vector
+
+`Vec α n` is indexed by its length `n : Nat` (one index, `numIndices = 1`).
+-/
+
+inductive Vec (α : Type) : Nat → Type where
+  | nil : Vec α 0
+  | cons {n : Nat} (head : α) (tail : Vec α n) : Vec α (n + 1)
+
+/-- A 2-element vector, so its root has type `Vec Nat 2`. -/
+def v : Vec Nat 2 := .cons 10 (.cons 20 .nil)
+
+-- Labels carry the length: the root reads `cons : Vec 2`, the next `cons : Vec 1`,
+-- and the terminal `nil : Vec 0`. The `type` field stays `Vec` throughout.
+#spytial v
+
+#spytial.datum v

--- a/demos/NotationLabels.lean
+++ b/demos/NotationLabels.lean
@@ -1,0 +1,90 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Notation-aware atom labels (`.notationLabel`)
+
+Lean elaborates notation away before the relationalizer runs, so `[1, 2, 3]`
+arrives as a `List.cons 1 (List.cons 2 (List.cons 3 List.nil))` term and renders
+as a four-atom cons chain (three `cons` nodes plus the `nil` terminator, with
+`head`/`tail` edges). That faithful structural view is often exactly what you
+want — but sometimes you would rather see the *surface syntax*.
+
+The `.notationLabel` spec op is an opt-in that collapses every value of a chosen
+type to a **single** atom labeled with the pretty-printed (delaborator-resugared)
+expression — `[1, 2, 3]`, `(1, 2)`, etc. It is a *relationalizer-side* op: it
+configures how terms are walked, not how the diagram is laid out, so it never
+appears in the YAML sent to spytial-core (per the project's partitioning rule).
+
+Selectors here use the **type-HEAD short name**, not the full applied type:
+write `.notationLabel (selector := "List")`, not `"List Nat"`. The head name is
+the same string that fills an atom's `type` field (`List`, `Prod`, …).
+
+Limitation: `.notationLabel` works in `with [...]` blocks only. Type-attached
+specs (`spytial_spec`) are stored as YAML and cannot carry it yet; writing one
+there is a clear error rather than a silent drop.
+-/
+
+/-! ## A list: cons chain vs. one collapsed atom
+
+Plain `#spytial` shows the structural cons chain: atoms `cons`, `cons`, `cons`,
+`nil` (all typed `List`) with `head` edges to the `Nat` leaves `1`, `2`, `3` and
+`tail` edges chaining them together — four `List` atoms in total.
+-/
+
+#spytial ([1, 2, 3] : List Nat)
+
+/-! With `.notationLabel (selector := "List")` the same value becomes ONE atom,
+    typed `List`, labeled `[1, 2, 3]`, with no relations. -/
+
+#spytial ([1, 2, 3] : List Nat) with [.notationLabel (selector := "List")]
+
+-- Expected collapsed data instance (one atom, no edges):
+--   atoms:     [{ id: atom_0, type: "List", label: "[1, 2, 3]" }]
+--   relations: []
+-- (The datum debug commands take no `with` block, so the collapsed JSON is noted
+--  here rather than printed; `#spytial.datum` below shows the un-collapsed chain.)
+#spytial.datum ([1, 2, 3] : List Nat)
+
+/-! ## Nested: the field collapses, the parent decomposes
+
+In `("xs", [1, 2]) : String × List Nat` the `Prod` is NOT in the collapse set, so
+it decomposes as usual into `mk` with `fst` / `snd` edges. The `snd` field is a
+`List`, which IS collapsed: it becomes a single `[1, 2]` atom instead of a cons
+chain. So collapse is per-type and applies wherever a matching value appears,
+however deeply nested.
+-/
+
+#spytial (("xs", [1, 2]) : String × List Nat) with [.notationLabel (selector := "List")]
+
+-- Expected: `Prod` atom `mk`; edge `fst` → String atom `"xs"`; edge `snd` → a
+-- single `List` atom labeled `[1, 2]`.
+
+/-! ## Collapsing `Prod` itself
+
+The type head for a pair is `Prod`, so `.notationLabel (selector := "Prod")`
+renders `(1, 2)` as one atom labeled `(1, 2)`.
+-/
+
+#spytial ((1, 2) : Nat × Nat) with [.notationLabel (selector := "Prod")]
+
+-- Expected: a single `Prod` atom labeled `(1, 2)`, no relations.
+
+/-! ## Combining with widget ops
+
+`.notationLabel` coexists with ordinary layout/styling ops in the same block: the
+relationalizer-side op configures the walk while the rest become the YAML. Here
+the list collapses to one atom AND that atom is colored.
+-/
+
+#spytial ([1, 2, 3] : List Nat) with [
+  .notationLabel (selector := "List"),
+  .atomColor (selector := "List") (value := "#0066ff")
+]
+
+-- `#spytial.spec` confirms the YAML carries ONLY the widget op — the
+-- `.notationLabel` op is stripped (it is not YAML):
+#spytial.spec ([1, 2, 3] : List Nat) with [
+  .notationLabel (selector := "List"),
+  .atomColor (selector := "List") (value := "#0066ff")
+]

--- a/demos/ProofState.lean
+++ b/demos/ProofState.lean
@@ -1,0 +1,118 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Proof-state visualization (`spytial_goals`)
+
+The `spytial_goals` tactic renders the CURRENT proof state — every goal and its
+local hypotheses — as one spatial relational diagram, instead of visualizing a
+single named value the way `spytial`/`#spytial` do.
+
+How the proof state maps to relations and atoms:
+
+- A hypothesis whose **type is a Prop application** `R a b …` headed by a named
+  symbol — either a constant (`LT.lt a b` from `a < b`) or a *local* relation
+  introduced by a binder / `variable (R : …)` (which is a free variable, not a
+  constant) — becomes a tuple in a relation named after `R`. The hypothesis
+  binder name (e.g. `h`) is *not* rendered — the relation name carries the
+  meaning. Only the data arguments are walked as atoms; proofs, types, and
+  instance arguments (e.g. the `LT Nat` instance inside `a < b`) are dropped.
+- A **data hypothesis** (a non-Prop type, e.g. `t : Tree`) is walked through the
+  normal relationalizer into the same diagram. An *abstract* hypothesis variable
+  (no definition) has no constructor structure, so it renders as a single atom
+  typed by its type's head; a let-bound or concrete value decomposes.
+- A Prop hypothesis that is **not** a named-symbol application (e.g. `∀ x, P x`,
+  `A ∧ B`, `A → B`) is skipped, with a one-line `logInfo` note so it isn't
+  silently missing.
+- Each **goal** target gets the same Prop-application treatment, but its relation
+  name is prefixed `⊢ ` so a spec can style goal structure differently from
+  hypotheses. A goal that is not a decomposable Prop application becomes a single
+  atom whose `type` field is `"Goal"`.
+
+It is **experimental**: the output shape may change. Tactic diff, dependency
+highlighting, and interactivity remain stretch goals (see issue #10).
+
+Because tactics run during elaboration, `lake build Demos` exercises everything
+below. The `spytial_goals_datum` calls print their JSON to the build log, which
+is the verification mechanism — no infoview required.
+-/
+
+/-! ## The motivating example: a symmetric relation
+
+`R` is a *local* relation (a `variable`, hence a free variable rather than a
+constant), and `spytial_goals` still names a relation after it. `h : R x y`
+becomes the relation `R` with the tuple `x → y`. The goal `R y x` becomes the
+goal relation `⊢ R` with the tuple `y → x`. The hypothesis
+`hsymm : ∀ a b, R a b → R b a` is a `∀`, not a relation application, so it is
+skipped — and `spytial_goals` logs a note saying one hypothesis was skipped. -/
+
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+  spytial_goals
+  exact hsymm x y h
+
+-- The same proof state inspected as JSON (printed to the build log): two
+-- relations — `R` with the tuple `x → y` (from `h`) and `⊢ R` with `y → x`
+-- (from the goal). Four atoms: `α` and `R` (the data hypotheses, walked as
+-- leaves), and `x`, `y` (shared between the `R` tuple and the `⊢ R` tuple, so
+-- both edges point at the SAME two nodes). `hsymm` (a `∀`) is skipped, with the
+-- one-line skip note.
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+  spytial_goals_datum
+  exact hsymm x y h
+
+/-! ## Mixed data + Prop hypotheses
+
+The data hypothesis `t : Tree` is an abstract local variable (no definition), so
+it has no constructor structure to descend into and renders as a single
+`Tree`-typed atom labeled `t`. Alongside it, the Prop hypothesis `hlt : a < b`
+is a const-headed application — `a < b` desugars to `@LT.lt Nat instLTNat a b`,
+whose *data* args (after dropping the type, the `LT Nat` instance, and any
+proofs) are `a` and `b` — so it becomes the relation `lt` with the tuple
+`a → b`. Data atom and relational edge coexist in the *same* diagram. -/
+
+inductive Tree where
+  | leaf : Tree
+  | node (key : Nat) (left : Tree) (right : Tree) : Tree
+  deriving Repr
+
+-- `t` and `hlt` are consumed by `spytial_goals` (it reads them out of the local
+-- context), but the syntactic linter only sees uses in the *proof term*, where
+-- they don't appear — hence we silence the unused-variable warning here.
+set_option linter.unusedVariables false in
+example (t : Tree) (a b : Nat) (hlt : a < b) : True := by
+  spytial_goals
+  trivial
+
+-- JSON view of the mixed state: one `Tree`-typed atom for `t`, the `lt` relation
+-- with the binary tuple `a → b` (the instance arg correctly dropped), and a
+-- `Goal`-typed atom for the `True` goal (`True` is a nullary prop — no data args
+-- to anchor a relation — so it falls back to a single `Goal` atom).
+set_option linter.unusedVariables false in
+example (t : Tree) (a b : Nat) (hlt : a < b) : True := by
+  spytial_goals_datum
+  trivial
+
+/-! ## Multiple goals
+
+`constructor` splits an `And` goal into two subgoals. With ≥ 2 goals open,
+`spytial_goals` walks BOTH into one diagram: each `P`/`Q` goal target becomes its
+own `⊢`-prefixed structure (here, single `Goal` atoms, since `P` and `Q` are
+opaque propositions sharing no const head). -/
+
+example (P Q : Prop) (hp : P) (hq : Q) : P ∧ Q := by
+  constructor
+  spytial_goals_datum
+  · exact hp
+  · exact hq
+
+-- A multi-goal state where the goals ARE relation applications: after
+-- `constructor` on `R x y ∧ R y x`, both subgoals decompose into `⊢ R` tuples
+-- (`x → y` and `y → x`) in the shared diagram.
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (hxy : R x y) (hyx : R y x) : R x y ∧ R y x := by
+  constructor
+  spytial_goals
+  · exact hxy
+  · exact hyx

--- a/demos/Quotients.lean
+++ b/demos/Quotients.lean
@@ -1,0 +1,53 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Quotient types
+
+`Quot` is kernel-primitive: `Quot.mk` is registered as `.quotInfo`, not as a
+constructor (`.ctorInfo`), so the relationalizer's constructor dispatch misses
+it and a quotient value would otherwise render as an opaque leaf.
+
+The relationalizer special-cases applications headed by `Quot.mk` (and the
+`Quotient.mk` / `Quotient.mk'` const heads, which usually reduce to `Quot.mk`
+under whnf). Such a value becomes an atom labeled `⟦·⟧` — the equivalence-class
+brackets — whose representative is walked as a child connected by a relation
+named `repr`. The atom's `type` is the head name of the value's type (`Quot`,
+`Quotient`, or a user def if whnf keeps it).
+
+The diagram therefore reads: "this is an equivalence class `⟦·⟧`, and here
+(`repr`) is the underlying representative we chose."
+-/
+
+/-! ## `Quot.mk` with an explicit relation
+
+No `Setoid` instance or equivalence proof is needed for `Quot.mk` — it takes the
+relation and the representative directly. Here the relation is "same value mod
+3", and `5` is the representative.
+-/
+
+#spytial (Quot.mk (fun a b : Nat => a % 3 = b % 3) 5)
+
+-- The `repr` edge points at the `Nat` atom `5`.
+#spytial.datum (Quot.mk (fun a b : Nat => a % 3 = b % 3) 5)
+
+/-! ## `Quotient.mk` via a `Setoid`
+
+A `Setoid` on `Nat × Nat` whose relation `r a b := a.1 + b.2 = b.1 + a.2`
+identifies pairs with the same difference (the usual integer construction). The
+`iseqv` proof is short with `omega`.
+-/
+
+instance diffSetoid : Setoid (Nat × Nat) where
+  r a b := a.1 + b.2 = b.1 + a.2
+  iseqv := {
+    refl := fun a => by omega
+    symm := fun h => by omega
+    trans := fun h1 h2 => by omega
+  }
+
+-- `(3, 1)` represents the class of pairs with difference 2.
+#spytial (Quotient.mk diffSetoid (3, 1))
+
+-- The `repr` edge points at the `Prod` representative `(3, 1)`.
+#spytial.datum (Quotient.mk diffSetoid (3, 1))

--- a/demos/Sharing.lean
+++ b/demos/Sharing.lean
@@ -1,0 +1,48 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Sharing (DAG-shared subterms)
+
+When the same subterm appears in more than one position of a value, the
+relationalizer does *not* duplicate it: `walkExpr` deduplicates structurally
+identical subterms by `Expr.hash`, so the two positions point at a single atom.
+The result is a directed acyclic graph (DAG) rather than a tree.
+
+To make that sharing visible, the second-and-later visit to a subterm flips a
+`shared := true` flag on the already-emitted atom (see `JsonAtom.shared` and
+`WalkState.markShared`). The *first* atom reached for a subterm keeps
+`shared := false`; once another parent reaches the same subterm, the flag turns
+on. spytial-core ignores the field today, so it is purely informational (a
+consumer could, for instance, draw shared nodes with a dashed border).
+
+Below, `sub` is built once and placed in both children of `t`, so the single
+`node 7 nil nil` subtree is shared. Inspect the `#spytial.datum` output to see
+`"shared": true` on the shared atom (and on the shared `nil` leaf).
+-/
+
+/-! ## A small tree -/
+
+inductive Tree where
+  | nil : Tree
+  | node (key : Nat) (left : Tree) (right : Tree) : Tree
+  deriving Repr
+
+/-- A subtree built once and reused in two positions of `t`. -/
+def sub : Tree := .node 7 .nil .nil
+
+/-- `t` places `sub` in both the left and right child, so `sub` is shared. -/
+def t : Tree := .node 1 sub sub
+
+-- The diagram shows a single `node 7` atom with two incoming edges (a DAG).
+#spytial t
+
+/-! ## Inspecting the `shared` flag
+
+The `#spytial.datum` command prints the JSON data instance. Look for the atom
+corresponding to `node 7 nil nil`: it carries `"shared": true`, because it was
+reached from both the `left` and the `right` edge of the root. The `nil` leaf
+under it is likewise shared.
+-/
+
+#spytial.datum t

--- a/demos/SpecInheritance.lean
+++ b/demos/SpecInheritance.lean
@@ -1,0 +1,173 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Spec inheritance through structure parent chains (issue #2)
+
+A `spytial_spec` attached to a type is the default layout used when a value of
+that type is visualized. This demo verifies — empirically, in the build log —
+that the spec lookup walks the *structure parent chain*, so a value of a derived
+type inherits the spec attached to its base type.
+
+The mechanism under test is `lookupTypeSpec` in `SpytialLean/Command.lean`. For a
+value whose head type is a structure, it reads the parent structures
+(`getAllParentStructures`, C3 linearization) and composes their specs root-first,
+merging the YAML (`mergeSpecYamls`). Because Lean 4 *classes are structures*, the
+exact same path makes `class B extends A` inherit `A`'s spec — no extra code.
+
+The `#spytial.typespec <term>` debug command prints precisely the YAML that
+`lookupTypeSpec` resolves (or `none`). It is the cleanest assertion of inheritance:
+if the parent chain works, the printed YAML contains lines from *every* spec in the
+chain. Each spec below uses a recognizable `.atomColor` value so you can read off,
+from the merged YAML, which specs were composed.
+
+Run `lake build Demos` and read the `#spytial.typespec` info diagnostics in the
+build log to see the merged YAML for each case.
+-/
+
+/-! ## 1. Baseline: plain structure extension
+
+`Derived extends Base`. A spec on `Base` should apply to a `Derived` value, and a
+spec on `Derived` itself should compose with it (root-first: Base, then Derived).
+-/
+
+structure Base where
+  tag : Nat
+  deriving Repr
+
+structure Derived extends Base where
+  extra : Nat
+  deriving Repr
+
+-- Distinct, recognizable colors so the merged YAML is self-documenting.
+spytial_spec Base [
+  .atomColor (selector := "Base") (value := "#336699")
+]
+
+spytial_spec Derived [
+  .atomColor (selector := "Derived") (value := "#cc3300")
+]
+
+def aDerived : Derived := { tag := 1, extra := 2 }
+
+-- The diagram uses the inherited+own spec as its default.
+#spytial aDerived
+
+-- Spec lookup, asserted in the build log. Expect the MERGED YAML containing both
+-- the Base color (#336699) and the Derived color (#cc3300), Base-first.
+#spytial.typespec aDerived
+
+-- A bare `Base` value resolves only Base's spec.
+def aBase : Base := { tag := 0 }
+#spytial.typespec aBase
+
+/-! ## 2. Type classes: `class Dog extends Animal`
+
+Lean 4 classes are structures, so this exercises the very same parent-chain path.
+A spec on the parent class `Animal` must apply to a `Dog` instance value.
+-/
+
+class Animal (α : Type) where
+  legs : Nat
+
+class Dog (α : Type) extends Animal α where
+  goodBoy : Bool
+
+instance : Animal Unit where
+  legs := 4
+
+instance : Dog Unit where
+  legs := 4
+  goodBoy := true
+
+spytial_spec Animal [
+  .atomColor (selector := "Animal") (value := "#118811")
+]
+
+spytial_spec Dog [
+  .atomColor (selector := "Dog") (value := "#8811cc")
+]
+
+-- A `Dog` instance value. `inferInstance` synthesizes the registered instance.
+def aDog : Dog Unit := inferInstance
+
+#spytial aDog
+
+-- Expect the MERGED YAML: Animal color (#118811) then Dog color (#8811cc).
+-- This is the key result: a parent *class*'s spec reaches a child instance.
+#spytial.typespec aDog
+
+-- An `Animal` instance resolves only Animal's spec.
+def anAnimal : Animal Unit := inferInstance
+#spytial.typespec anAnimal
+
+/-! ## 3. Deeper chain (3 levels): C3 linearization order
+
+`Vehicle ← Car ← SportsCar`. The composed YAML must list the specs root-first
+(Vehicle, Car, SportsCar), demonstrating the C3 linearization order produced by
+`getAllParentStructures` (reversed to root-first, self last).
+-/
+
+structure Vehicle where
+  wheels : Nat
+  deriving Repr
+
+structure Car extends Vehicle where
+  doors : Nat
+  deriving Repr
+
+structure SportsCar extends Car where
+  topSpeed : Nat
+  deriving Repr
+
+spytial_spec Vehicle [
+  .atomColor (selector := "Vehicle") (value := "#111111")
+]
+
+spytial_spec Car [
+  .atomColor (selector := "Car") (value := "#222222")
+]
+
+spytial_spec SportsCar [
+  .atomColor (selector := "SportsCar") (value := "#333333")
+]
+
+def aSportsCar : SportsCar := { wheels := 4, doors := 2, topSpeed := 300 }
+
+#spytial aSportsCar
+
+-- Expect the MERGED YAML in root-first order:
+--   Vehicle (#111111), Car (#222222), SportsCar (#333333).
+#spytial.typespec aSportsCar
+
+/-! ## Deferred cases (issue #2 stays open)
+
+The issue also asks for three further forms of spec inheritance. All three are
+deferred with rationale recorded in `PLAN.md` (the "#2" section); see
+<https://github.com/sidprasad/spytial-lean/issues/2>. They are NOT implemented
+here:
+
+1. **Explicit `spytial_spec X extends Y` syntax** for plain inductives that are
+   *not* connected by a structure parent chain (e.g. an `RBNode` that should
+   reuse a `Tree` spec). New surface syntax for a niche need — wait for demand.
+
+2. **Per-instantiation specs** (`List Nat` distinct from `List`). The spec store
+   is keyed by `Name`, so it cannot today distinguish a type by its arguments.
+   Keying by type *expression* is a storage-format migration — follow-up.
+
+3. **Subtype inheritance.** A value of `{x : Nat // x > 0}` is headed by
+   `Subtype` and is a `Subtype.mk` pair; silently inheriting `Nat`'s spec would
+   mislabel the wrapper atom. Needs its own design.
+
+### Status quo for the Subtype case
+
+The current behavior, as documentation: a Subtype value resolves NO spec, because
+its head type is `Subtype` (no `spytial_spec` attached) and `lookupTypeSpec` does
+not unwrap it. Expect `#spytial.typespec` to print `none` below even though `Nat`
+itself could carry a spec — confirming that Subtype inheritance is not (yet) wired.
+-/
+
+def aPositive : { x : Nat // x > 0 } := ⟨1, by decide⟩
+
+-- Expect: none (Subtype carries no spec; the base type's spec is not inherited).
+#spytial.typespec aPositive

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -71,7 +71,8 @@ lean_lib SpytialLean where
 
 lean_lib Demos where
   srcDir := "demos"
-  roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer]
+  roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
+             `Sharing, `Quotients, `IndexedFamilies]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,8 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance,
+             `ProofState]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels]
   needs := #[widgetJsAll]
 
 require proofwidgets from


### PR DESCRIPTION
## Summary

This PR works through the open-issue roadmap: 8 of the 10 open issues are implemented, 1 is verified-and-partially-deferred, and 1 is deliberately deferred to a separate project. All design decisions are recorded in [`PLAN.md`](PLAN.md), maintained in-repo so the rationale outlives the diff.

Every feature lands with a runnable demo under `demos/` (registered in the `Demos` lib roots) and was verified with `lake build` + `lake build Demos` green before each commit.

## What changed, by issue

| Issue | Feature | How |
|-------|---------|-----|
| [#22](https://github.com/sidprasad/spytial-lean/issues/22) | **DAG-shared subterms** | `JsonAtom.shared` flag, set on the second-and-later visit to a hash-cached subterm. Visible in `#spytial.datum`; widget styling deferred to spytial-core (data already carries the flag). |
| [#9](https://github.com/sidprasad/spytial-lean/issues/9) | **Quotient types** | `Quot.mk`/`Quotient.mk` applications become a `⟦·⟧` atom with a `repr` edge to the representative, instead of an opaque leaf. |
| [#21](https://github.com/sidprasad/spytial-lean/issues/21) | **Indexed families** | Constructor atoms of indexed inductives carry their type indices in the label (`cons : Vec 2`). The `type` field stays stable so selectors are unaffected. |
| [#13](https://github.com/sidprasad/spytial-lean/issues/13) | **Structural function bodies** | For non-finite domains (where we used to emit a leaf), decompose the body: `ite`/`dite` → `if` node, matcher/`casesOn` → `match` node with per-constructor branches, `letE` → `let` node, nested lambdas peel one binder per layer. Finite-domain enumeration is unchanged. |
| [#8](https://github.com/sidprasad/spytial-lean/issues/8) | **`#spytial.enumerate`** | New command renders all inhabitants of a finite type into one shared diagram. No `Fintype`/Mathlib dependency (uses the existing `tryEnumerateDomain`). `#spytial f` already enumerates finite function domains, so no `#spytial.map` variant. |
| [#24](https://github.com/sidprasad/spytial-lean/issues/24) | **`.notationLabel`** | New relationalizer-side spec op collapses a type-head's values into one atom labeled with the delaborator-resugared surface syntax (`[1, 2, 3]` instead of a cons chain). Partitioned out of the widget YAML into `WalkConfig`. |
| [#2](https://github.com/sidprasad/spytial-lean/issues/2) | **Type-class spec inheritance** | Verified that Lean 4 classes (which *are* structures) already inherit specs through the existing parent-chain walk; added a demo proving it and a `#spytial.typespec` debug command. Explicit-`extends` syntax, per-instantiation specs, and Subtype inheritance stay deferred with rationale. |
| [#23](https://github.com/sidprasad/spytial-lean/issues/23) | **Size limits** | `WalkConfig.maxAtoms` (default 5000) caps total atoms via a single `freshAtomId` chokepoint; README gains a "Performance and limits" section with measured timings. |
| [#10](https://github.com/sidprasad/spytial-lean/issues/10) | **`spytial_goals` (experimental)** | New tactic walks the proof state into one diagram: first-order Prop hypotheses become relation edges, goals get a `⊢ ` prefix. Diff/highlighting/interactivity remain stretch goals. |
| [#20](https://github.com/sidprasad/spytial-lean/issues/20) | **Mathlib demo** | **Deferred** — an optional Mathlib `lean_lib` would force multi-GB resolution on every `lake update`/CI run; the right shape is a standalone project, and it needs a human reviewing rendered output. Rationale in PLAN.md. |

## Design decisions worth flagging

- **Selector stability is sacrosanct.** The atom `type` field is part of the public selector API. Features enrich *labels* freely (indices, notation, quotient markers) but never change existing `type` strings or relation names.
- **No Mathlib in core.** #8 explicitly avoids `Fintype`; #20 is deferred for the same reason.
- **Relationalizer-side ops don't reach the widget.** `.notationLabel` configures the walk, not the layout, so it's partitioned into `WalkConfig` and stripped from the emitted YAML — keeping spytial-core's input exactly what `parseLayoutSpec` understands.
- **Strict improvements only.** Where a term was an opaque leaf, decomposing further is fine; where it already decomposed, default output shape is unchanged (new behavior is opt-in).

## Verification

- `lake build` and `lake build Demos` both green (including a clean-from-scratch rebuild).
- An adversarial review pass over the combined diff surfaced one real hazard — a possible elaborator panic on an under-applied matcher in the new function-body decomposition — which is fixed (`8cc06d5`) with a guarded index plus the cross-feature `maxAtoms` consistency cleanup.

## Notes for the reviewer

- `spytial_goals` is marked **experimental**; relation extraction is best-effort for first-order propositions (`∀`/`∧`/`→` hypotheses are skipped with a logged note).
- The widget JS is unchanged — the `shared` flag rides along in the data instance for a future spytial-core styling pass.
- Issues #2 and #10 should stay **open** (partial/experimental); the rest are fully addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
