### PR TITLE
Relationalizer term-shapes: sharing, quotients, indices, function bodies (#22 #9 #21 #13)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,153 @@
+# spytial-lean roadmap plan
+
+This document records the design decisions for the open issue backlog and tracks
+implementation status. It is maintained in-repo so decisions survive the PRs that
+implement them. Last updated: 2026-06-10.
+
+## Guiding principles
+
+1. **Selectors must stay stable.** The `type` field of an atom is part of the
+   user-facing spec API (selectors match on it). Features may enrich *labels*
+   freely, but must not change existing `type` strings or relation names.
+2. **No Mathlib dependency in the core library or default demos.** Anything that
+   needs `Fintype`, `Subgroup`, etc. lives in a separate, optional project.
+3. **Relationalizer behavior changes must be strict improvements.** Where a term
+   today renders as an opaque leaf, decomposing it further is fine. Where it
+   already decomposes, the default output must not change shape (opt-in only).
+4. **Spec ops that affect the relationalizer (not the widget) are partitioned
+   out of the YAML** and become `WalkConfig` fields. The YAML remains exactly
+   what spytial-core's `parseLayoutSpec` understands.
+
+## Decisions and status
+
+### #22 — Surface DAG-shared subterms — **DONE (this PR)**
+
+**Decision: Option 1 (shared flag), least invasive.**
+`WalkState.seen` already deduplicates by `Expr.hash`. On a second visit we now
+mark the existing atom `shared := true`. `JsonAtom.shared` serializes as an
+extra JSON field, which spytial-core ignores today; the flag is visible in
+`#spytial.datum` output, and a `demos/Sharing.lean` demo documents the
+behavior. Distinct visual styling (dashed border) belongs in spytial-core and
+is deferred there — the data already carries the flag it would need.
+
+### #9 — Quotient type visualization — **DONE (this PR)**
+
+**Decision: detect `Quot.mk`-headed terms, walk the representative.**
+`Quot` is kernel-primitive (`.quotInfo`, not `.ctorInfo`), so the constructor
+dispatch misses it and it falls through to an opaque leaf. We special-case
+applications headed by `Quot.mk` / `Quotient.mk` / `Quotient.mk'`: the atom is
+labeled `⟦·⟧`, typed by the quotient type's head name, and the underlying
+representative is walked as a child via a `repr` relation. The equivalence-class
+view (multiple representatives grouped) is a stretch goal, deferred.
+
+### #21 — Indices of indexed inductive families — **DONE (this PR)**
+
+**Decision: surface indices in the atom label; keep `type` stable.**
+When a constructor's inductive has `numIndices > 0`, we read the index
+expressions off the value's *type* (the trailing `numIndices` arguments) and
+append them to the label: `cons : Vec 2`. The `type` field stays the head
+constant's short name, so existing selectors are unaffected. The synthetic
+`__index_n` relation and spec-projected variants from the issue are rejected:
+indices are type-level data, and edges to them would suggest runtime structure
+that isn't there.
+
+### #13 — Structural decomposition of function bodies — **DONE (this PR)**
+
+**Decision: structural decomposition only where today we show a leaf.**
+Finite-domain enumeration (the #6 behavior) remains the default for enumerable
+domains — extensional view first. For *non-finite* domains, where today the
+lambda is an opaque labeled node, we enter the binder (`withLocalDecl`),
+`whnfCore` the body, and decompose:
+
+- `ite` / `dite` → node labeled `if`, edges `condition` / `then` / `else`
+- `T.casesOn` applications → node labeled `match`, edge `match` to the
+  discriminant, one edge per branch labeled by constructor name
+- `Expr.letE` → edges `let_value` / `let_body`
+- nested lambdas → recurse (multi-argument functions)
+
+Anything else falls back to the current leaf label. A spec flag to force one
+view or the other is deferred until someone asks for it.
+
+### #8 — Finite type enumeration — **DONE (this PR)**
+
+**Decision: `#spytial.enumerate <Type>` command, no `Fintype`, no `#spytial.map`.**
+The issue proposes `[Fintype α]`, but `Fintype` is Mathlib — violates
+principle 2. We already have `tryEnumerateDomain` (Bool, `Fin n` for n ≤ 20,
+zero-arity enum inductives); the new command elaborates its argument as a type,
+enumerates the inhabitants, and walks them all into a single shared diagram
+(so a function field pointing at an enumerated element unifies with it).
+`#spytial.map f` is unnecessary: `#spytial f` already enumerates finite
+domains via the lambda arm — the demo shows this. Non-enumerable types get a
+clear error naming what is supported.
+
+### #2 — Spec lookup for parent-child relationships — **PARTIAL (this PR)**
+
+**Decision: type classes work through the existing structure path; verify and
+demo it; defer the rest.** Lean 4 classes *are* structures, so
+`lookupTypeSpec`'s parent-chain walk already covers `class B extends A`.
+This PR adds a demo proving it (spec on a parent class applies to a child
+class instance). Deferred with rationale:
+
+- *Explicit `spytial_spec RBNode extends Tree`*: new syntax for a niche need;
+  wait for demand.
+- *Per-instantiation specs (`List Nat` vs `List`)*: the spec store is keyed by
+  `Name`; keying by type expression is a storage-format migration. Follow-up.
+- *Subtype inheritance*: `{x : Nat // x > 0}` is headed by `Subtype`, and
+  values are `Subtype.mk` pairs — inheriting the base type's spec silently
+  would mislabel the wrapper atom. Needs its own design.
+
+Issue stays open for the deferred cases.
+
+### #24 — Notation-aware atom labels — **DONE (this PR)**
+
+**Decision: route 1, per-spec opt-in via a new `.notationLabel` op.**
+New op `.notationLabel (selector := "<TypeHeadName>")`. It is neither a
+constraint nor a directive: per principle 4 it never reaches the YAML.
+`#spytial`'s elaborator partitions it into `WalkConfig.collapseTypes`; when the
+walker reaches an expression whose type-head short name matches, it emits a
+single atom labeled with the *pre-whnf* pretty-printed expression (the
+delaborator restores `[1, 2, 3]`, `(a, b)`, `a + b`) and does not decompose.
+Limitation, documented: works in `with [...]` blocks only. Type-attached specs
+(`spytial_spec`) store YAML, so relationalizer-side ops can't round-trip
+through them until the storage format carries structured ops — follow-up.
+
+### #23 — Term-size limits — **DONE (this PR)**
+
+**Decision: measure, document, and add a `maxAtoms` guard.**
+`WalkConfig.maxAtoms : Nat := 5000`; exceeding it throws a clear error rather
+than hanging the editor. Benchmarks (relationalize time for `List.range N`,
+a deep RBNode, a proof term) are recorded in the README "Performance and
+limits" section with measured numbers and soft guidance.
+
+### #10 — Proof-state visualization (`spytial_goals`) — **DONE (this PR)**
+
+**Decision: ship the basic tactic, mark it experimental.**
+`spytial_goals` walks the local context and goals of the current proof state:
+
+- Hypotheses whose type is a const-headed Prop application `R a b …` become
+  tuples in a relation named `R` (data args walked as atoms, proof args
+  skipped).
+- Data-typed hypotheses are relationalized normally.
+- Goals get the same treatment, but their relations are prefixed `⊢ ` so specs
+  can style hypothesis vs. goal differently.
+
+Tactic diff (before/after), dependency highlighting, and interactivity are
+stretch goals and stay in the issue.
+
+### #20 — Mathlib smoke-test demo — **DEFERRED**
+
+**Decision: separate project, separate PR.** Even an optional `lean_lib` in
+this lakefile would force Mathlib onto every `lake update` resolution and CI
+run (multi-GB artifacts). The right shape is a standalone `demos-mathlib/`
+lake project that `require`s both spytial-lean and Mathlib, exercised manually
+or in a dedicated CI job with `lake exe cache get`. It also genuinely needs a
+human looking at the rendered output (screenshots in the PR), which is the
+point of the issue. Stays open.
+
+## Execution notes
+
+- Agents work sequentially on one checkout (lake builds can't safely run
+  concurrently in one dir); each change is verified with `lake build`
+  (library + demos) before commit.
+- Every feature lands with a demo file registered in the `Demos` lib roots in
+  `lakefile.lean`.

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -33,6 +33,11 @@ def WalkState.addTuple (s : WalkState) (relName : String) (types : Array String)
 def WalkState.markSeen (s : WalkState) (hash : UInt64) (atomId : String) : WalkState :=
   { s with seen := s.seen.insert hash atomId }
 
+/-- Mark an already-emitted atom as DAG-shared (visited from more than one
+    parent). Finds the atom by id in `atoms` and sets its `shared` flag. -/
+def WalkState.markShared (s : WalkState) (atomId : String) : WalkState :=
+  { s with atoms := s.atoms.map fun a => if a.id == atomId then { a with shared := true } else a }
+
 /-- Convert accumulated state to a JsonDataInstance. -/
 def WalkState.toDataInstance (s : WalkState) : JsonDataInstance :=
   let relations := s.relations.toArray.map fun (name, types, tuples) =>
@@ -131,10 +136,13 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
   -- WHNF reduce to expose constructors
   let e ← Meta.whnf eOrig
 
-  -- Check for cycles
+  -- Check for cycles / DAG sharing
   let hash := e.hash
   let s ← get
   if let some existingId := s.seen[hash]? then
+    -- Revisiting a structurally identical subterm: mark the already-emitted
+    -- atom as shared so downstream consumers can style it distinctly.
+    modify fun s => s.markShared existingId
     return existingId
 
   let ty ← Meta.inferType e
@@ -187,9 +195,9 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     return atomId
 
   | _ => do
-    -- Try to get the type name
+    -- Try to get the type name (keep the whnf'd type around for index reading)
+    let tyWhnf ← Meta.whnf ty
     let typeName ← do
-      let tyWhnf ← Meta.whnf ty
       match tyWhnf.getAppFn with
       | .const n _ => pure (shortName n)
       | _ => pure (← ppLabel ty)
@@ -198,10 +206,51 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     match e.getAppFn with
     | .const fnName _ => do
       let env ← getEnv
+      -- Quotient values: `Quot.mk r repr` is kernel-primitive (`.quotInfo`,
+      -- not `.ctorInfo`), so it misses the constructor check below and would
+      -- otherwise become an opaque leaf. We special-case it: emit a `⟦·⟧`
+      -- atom and walk the representative (the last argument) via a `repr` edge.
+      -- `Quotient.mk` / `Quotient.mk'` usually reduce to `Quot.mk` under whnf,
+      -- but we match those const heads too in case whnf stopped early.
+      if fnName == ``Quot.mk || fnName == ``Quotient.mk || fnName == ``Quotient.mk' then
+        let args := e.getAppArgs
+        modify fun s => s.addAtom { id := atomId, type := typeName, label := "⟦·⟧" }
+        -- A full application has ≥ 3 args; the representative is the last one.
+        if args.size ≥ 3 then
+          let repr := args[args.size - 1]!
+          let childId ← walkExpr cfg repr
+          modify fun s => s.addTuple "repr" #[typeName, typeName]
+            { atoms := #[atomId, childId], types := #[typeName, typeName] }
+        return atomId
       -- Is it a constructor?
-      if let some (.ctorInfo ci) := env.find? fnName then
+      else if let some (.ctorInfo ci) := env.find? fnName then
         let ctorShortName := shortName fnName
-        modify fun s => s.addAtom { id := atomId, type := typeName, label := ctorShortName }
+        -- Indexed inductive families: surface the index expressions in the
+        -- label (e.g. `cons : Vec 2`) so atoms at different indices are
+        -- distinguishable. The `type` field stays the head const short name —
+        -- selectors depend on it, so only the *label* changes, and only when
+        -- the family actually has indices.
+        let label ← do
+          let indVal? := env.find? ci.induct
+          match indVal? with
+          | some (.inductInfo iv) =>
+            if iv.numIndices > 0 then
+              -- The value's type is `T params… indices…`; read the trailing
+              -- `numIndices` arguments off the (already whnf'd) type.
+              let tyArgs := tyWhnf.getAppArgs
+              let indexExprs := tyArgs.extract (tyArgs.size - iv.numIndices) tyArgs.size
+              let mut indexStrs : Array String := #[]
+              for ix in indexExprs do
+                -- Reduce the index to a normal form so e.g. `n + 1` with a
+                -- literal `n` prints as `2`, not `1 + 1`.
+                let ixR ← Meta.whnf ix
+                indexStrs := indexStrs.push (← ppLabel ixR)
+              let joined := String.intercalate " " indexStrs.toList
+              pure s!"{ctorShortName} : {typeName} {joined}"
+            else
+              pure ctorShortName
+          | _ => pure ctorShortName
+        modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
         -- Extract binder names from the constructor type (skip type params)
         let mut binderNames : Array Name := #[]
         let mut ctorTy := ci.type

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -128,6 +128,58 @@ def tryEnumerateDomain (ty : Expr) : MetaM (Option (Array (String × Expr))) := 
     else return none
   | _ => return none
 
+/-- Weak-head normalize a function body just enough to expose its top-level
+    structure (`ite` / `dite` / matcher / `casesOn` / `letE`), WITHOUT unfolding
+    definitions (so notation like `n * 2` survives) and WITHOUT zeta-reducing
+    `let`s (so `letE` stays visible to surface as a `let` node). -/
+def whnfBody (e : Expr) : MetaM Expr :=
+  Meta.withConfig (fun c => { c with zeta := false, zetaDelta := false })
+    (Meta.whnfCore e)
+
+/-- Short name of a type's head constant (whnf'd), or its pretty-printed form
+    if the head is not a constant. Used to fill the `type` field of atoms. -/
+def typeShortName (ty : Expr) : MetaM String := do
+  match (← Meta.whnf ty).getAppFn with
+  | .const n _ => pure (shortName n)
+  | _ => pure (← ppLabel ty)
+
+/-- The data needed to decompose a `T.casesOn` application: the inductive's
+    parameter / index counts and its constructors in declaration order. -/
+structure CasesOnInfo where
+  numParams : Nat
+  numIndices : Nat
+  ctors : Array Name
+
+/-- Emit a single leaf atom for an already-reduced expression and return its id.
+
+    Pretty-prints `e` *as given* (no further reduction). The structural walker
+    uses this for leaves of a function body so that arithmetic on the bound
+    variable keeps its surface form (`n * 2`) instead of being unfolded by the
+    full `whnf` that `walkExpr` would apply at its entry. -/
+def emitLeaf (e : Expr) : StateT WalkState MetaM String := do
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  let typeName ← typeShortName (← Meta.inferType e)
+  let label ← ppLabel e
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
+  return atomId
+
+/-- If `fnName` is `T.casesOn` for an inductive `T`, return the `CasesOnInfo`
+    describing `T`; otherwise `none`. The name must be `Name.str indName "casesOn"`
+    where `indName` resolves to an `InductiveVal`. -/
+def isCasesOnApp? (fnName : Name) : MetaM (Option CasesOnInfo) := do
+  match fnName with
+  | .str indName "casesOn" =>
+    match (← getEnv).find? indName with
+    | some (.inductInfo iv) =>
+      return some { numParams := iv.numParams, numIndices := iv.numIndices,
+                    ctors := iv.ctors.toArray }
+    | _ => return none
+  | _ => return none
+
+mutual
+
 /-- Walk a Lean expression and produce atoms + relations.
     Returns the atom ID assigned to this expression. -/
 partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState MetaM String := do
@@ -171,8 +223,10 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     modify fun s => s.addAtom { id := atomId, type := "String", label := s!"\"{str}\"" }
     return atomId
 
-  -- Lambda — try to enumerate finite domain, otherwise labeled node
-  | .lam binderName binderType _body _bi => do
+  -- Lambda — try to enumerate finite domain (extensional view, what it
+  -- computes); otherwise decompose the body structurally (intensional view,
+  -- how it is defined) instead of leaving an opaque leaf.
+  | .lam binderName binderType body bi => do
     let typeName ← do
       let tyWhnf ← Meta.whnf ty
       match tyWhnf.getAppFn with
@@ -186,12 +240,24 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
     let domainElems ← tryEnumerateDomain binderType
     match domainElems with
     | some elems =>
+      -- Extensional view: enumerate input→output edges. This is the default
+      -- for enumerable domains and its output shape must not change.
       for (elemLabel, elemExpr) in elems do
         let result ← Meta.whnf (Expr.app e elemExpr)
         let childId ← walkExpr cfg result
         modify fun s => s.addTuple elemLabel #[typeName, typeName]
           { atoms := #[atomId, childId], types := #[typeName, typeName] }
-    | none => pure ()  -- non-finite domain, just a labeled node
+    | none =>
+      -- Non-finite domain: decompose the body structurally. Enter the binder
+      -- so the bound variable is a free variable in scope, then walk the body
+      -- through the structural walker. All walking happens INSIDE the
+      -- `withLocalDecl` continuation so `ppExpr`/`inferType` on subterms
+      -- containing the fvar succeed.
+      Meta.withLocalDecl binderName bi binderType fun fv => do
+        let bodyExpr := body.instantiate1 fv
+        let childId ← walkBody cfg bodyExpr
+        modify fun s => s.addTuple "body" #[typeName, typeName]
+          { atoms := #[atomId, childId], types := #[typeName, typeName] }
     return atomId
 
   | _ => do
@@ -311,6 +377,197 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
       let label ← ppLabel e
       modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
       return atomId
+
+/-- Structurally decompose a function body (intensional view).
+
+    Used by the non-finite path of `walkExpr`'s `.lam` arm. `whnfBody`-reduces
+    the expression (weak-head, no definition unfolding, no `let` zeta) and
+    dispatches on its shape:
+
+    - `ite` / `dite` applications → a node labeled `if` with `condition` /
+      `then` / `else` edges (`dite` branches are lambdas over the decidability
+      proof; their bodies are decomposed through `walkBodyLam`).
+    - matcher auxiliaries (`f.match_n`) and `T.casesOn` applications → a node
+      labeled `match`, a `match` edge to the discriminant, and one edge per
+      branch labeled by the corresponding constructor's short name. Branch
+      bodies are lambdas over the constructor fields, decomposed via
+      `walkBodyLam` (so nested structure surfaces).
+    - `Expr.letE` → a node labeled `let` with `let_value` / `let_body` edges.
+    - nested `.lam` → recurse: multi-argument functions decompose one binder at
+      a time, the inner lambda reached via a `body` edge from `walkExpr`.
+
+    Anything else (the bound variable itself, applications of it, arithmetic on
+    it) falls back to `walkExpr`, which pretty-prints a leaf label like `n * 2`.
+    Recursive sub-parts go back through `walkBody`, so nested `if`s nest. -/
+partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
+    StateT WalkState MetaM String := do
+  -- Detect `T.casesOn` BEFORE reducing: `whnfBody` would unfold it to `T.rec`
+  -- (a different, harder-to-read shape). Matchers, `ite`/`dite`, and `letE` all
+  -- survive `whnfBody`, so they are handled after reduction below.
+  if let .const fnName _ := e.getAppFn then
+    if let some info ← isCasesOnApp? fnName then
+      return ← walkCasesOn cfg e info e.getAppArgs
+  let e ← whnfBody e
+  match e.getAppFn with
+  | .const fnName _ =>
+    let args := e.getAppArgs
+    -- if / dite: `@ite α c inst t e` / `@dite α c inst t e` — both have 5 args
+    -- with the condition at index 1, the `then` branch at 3, `else` at 4.
+    if (fnName == ``ite || fnName == ``dite) && args.size == 5 then
+      let isDite := fnName == ``dite
+      let ty ← Meta.inferType e
+      let typeName ← typeShortName ty
+      let s ← get
+      let (atomId, s) := s.freshId
+      set s
+      modify fun s => s.addAtom { id := atomId, type := typeName, label := "if" }
+      let condId ← walkBody cfg args[1]!
+      modify fun s => s.addTuple "condition" #[typeName, typeName]
+        { atoms := #[atomId, condId], types := #[typeName, typeName] }
+      -- `dite` branches abstract over the proof of `c` (resp. `¬ c`); peel that
+      -- binder off and decompose the branch body. `ite` branches are plain.
+      let thenId ← if isDite then walkBodyLam cfg args[3]! else walkBody cfg args[3]!
+      modify fun s => s.addTuple "then" #[typeName, typeName]
+        { atoms := #[atomId, thenId], types := #[typeName, typeName] }
+      let elseId ← if isDite then walkBodyLam cfg args[4]! else walkBody cfg args[4]!
+      modify fun s => s.addTuple "else" #[typeName, typeName]
+        { atoms := #[atomId, elseId], types := #[typeName, typeName] }
+      return atomId
+    -- Matcher auxiliary (`f.match_n`): a pattern match compiled to a matcher.
+    -- Layout of its application args is `[params] [motive] [discrs] [alts]`.
+    else if let some mi ← Meta.getMatcherInfo? fnName then
+      walkMatch cfg e mi args
+    -- `T.casesOn` is normally caught pre-reduction above (whnf unfolds it to
+    -- `T.rec`); this is a defensive fallback for any that slips through.
+    else if let some info ← isCasesOnApp? fnName then
+      walkCasesOn cfg e info args
+    else if (← getEnv).find? fnName matches some (.ctorInfo _) then
+      -- A constructor application (possibly mentioning the bound variable, e.g.
+      -- `x :: xs`): let `walkExpr` decompose it into its fields as usual.
+      walkExpr cfg e
+    else
+      -- Other const application on the bound variable (arithmetic, comparisons,
+      -- a recursive call): emit a leaf from the surface form. Going through
+      -- `walkExpr` here would full-`whnf` and unfold e.g. `n * 2` into
+      -- `(n.mul 1).add n`; `emitLeaf` keeps the readable `n * 2`.
+      emitLeaf e
+  | .letE declName declType value body _nonDep =>
+    -- Surface a `let`: walk the bound value, then the body with the let
+    -- variable in scope as a local decl.
+    let ty ← Meta.inferType e
+    let typeName ← typeShortName ty
+    let s ← get
+    let (atomId, s) := s.freshId
+    set s
+    modify fun s => s.addAtom { id := atomId, type := typeName, label := s!"let {declName}" }
+    let valId ← walkBody cfg value
+    modify fun s => s.addTuple "let_value" #[typeName, typeName]
+      { atoms := #[atomId, valId], types := #[typeName, typeName] }
+    Meta.withLetDecl declName declType value fun fv => do
+      let bodyExpr := body.instantiate1 fv
+      let bodyId ← walkBody cfg bodyExpr
+      modify fun s => s.addTuple "let_body" #[typeName, typeName]
+        { atoms := #[atomId, bodyId], types := #[typeName, typeName] }
+    return atomId
+  | .lam .. =>
+    -- Nested lambda (multi-argument function). Hand back to `walkExpr`, whose
+    -- `.lam` arm emits the lambda atom and recurses into its body via a `body`
+    -- edge — so each binder becomes its own layer.
+    walkExpr cfg e
+  | .lit _ =>
+    -- A bare literal: `walkExpr` already renders these cleanly (and `whnf` is
+    -- harmless on literals).
+    walkExpr cfg e
+  | _ =>
+    -- Bound variable, projection, or any other non-application head: emit a
+    -- leaf from the surface form (e.g. the binder name `n`, or `n.fst`).
+    emitLeaf e
+
+/-- Decompose a branch lambda: peel its binders (constructor fields, or a
+    `dite` decidability proof), introducing a fresh local for each, then walk
+    the resulting body structurally. Used for matcher/`casesOn` alternatives and
+    `dite` branches, whose bodies are lambdas we want to see *through* rather
+    than render as `λ`-leaves. -/
+partial def walkBodyLam (cfg : WalkConfig := {}) (e : Expr) :
+    StateT WalkState MetaM String := do
+  let e ← whnfBody e
+  match e with
+  | .lam binderName binderType lamBody bi =>
+    Meta.withLocalDecl binderName bi binderType fun fv => do
+      walkBodyLam cfg (lamBody.instantiate1 fv)
+  | _ => walkBody cfg e
+
+/-- Decompose a matcher application into a `match` node: an edge `match` to the
+    walked discriminant and one edge per alternative, labeled by the matching
+    constructor's short name. `mi` is the matcher's `MatcherInfo`; `args` are the
+    full application arguments laid out as `[params] [motive] [discrs] [alts]`. -/
+partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
+    (mi : Lean.Meta.MatcherInfo) (args : Array Expr) :
+    StateT WalkState MetaM String := do
+  let ty ← Meta.inferType e
+  let typeName ← typeShortName ty
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
+  -- Discriminants sit right after the motive (one motive slot, then numDiscrs).
+  let discrStart := mi.numParams + 1
+  let altStart := discrStart + mi.numDiscrs
+  -- Walk each discriminant via the standard walker and link it with `match`.
+  let discrs := args.extract discrStart altStart
+  let mut ctorNames : Array String := #[]
+  for discr in discrs do
+    let discrId ← walkExpr cfg discr
+    modify fun s => s.addTuple "match" #[typeName, typeName]
+      { atoms := #[atomId, discrId], types := #[typeName, typeName] }
+  -- Constructor order for branch labels comes from the discriminant's
+  -- inductive (single-discriminant matches are the common case).
+  if mi.numDiscrs == 1 then
+    let dty ← Meta.inferType discrs[0]!
+    match (← Meta.whnf dty).getAppFn with
+    | .const indName _ =>
+      if let some (.inductInfo iv) := (← getEnv).find? indName then
+        ctorNames := iv.ctors.toArray.map shortName
+    | _ => pure ()
+  -- One edge per alternative; the branch body is a lambda over its ctor fields.
+  let alts := args.extract altStart args.size
+  for h : i in [:alts.size] do
+    let altId ← walkBodyLam cfg alts[i]
+    let edgeName := if h : i < ctorNames.size then ctorNames[i] else s!"case_{i}"
+    modify fun s => s.addTuple edgeName #[typeName, typeName]
+      { atoms := #[atomId, altId], types := #[typeName, typeName] }
+  return atomId
+
+/-- Decompose a `T.casesOn` application into a `match` node, analogous to
+    `walkMatch`. Args are `[params] [motive] [indices] [major] [alts]`; `info`
+    carries the inductive's `numParams` / `numIndices` and the ctor order. -/
+partial def walkCasesOn (cfg : WalkConfig := {}) (e : Expr)
+    (info : CasesOnInfo) (args : Array Expr) :
+    StateT WalkState MetaM String := do
+  let ty ← Meta.inferType e
+  let typeName ← typeShortName ty
+  let s ← get
+  let (atomId, s) := s.freshId
+  set s
+  modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
+  -- Major (the scrutinee) sits after params, motive, and indices.
+  let majorPos := info.numParams + 1 + info.numIndices
+  if h : majorPos < args.size then
+    let majorId ← walkExpr cfg args[majorPos]
+    modify fun s => s.addTuple "match" #[typeName, typeName]
+      { atoms := #[atomId, majorId], types := #[typeName, typeName] }
+  -- Branches follow the major, one per constructor in declaration order.
+  let altStart := majorPos + 1
+  let alts := args.extract altStart args.size
+  let ctorNames := info.ctors.map shortName
+  for h : i in [:alts.size] do
+    let altId ← walkBodyLam cfg alts[i]
+    let edgeName := if h : i < ctorNames.size then ctorNames[i] else s!"case_{i}"
+    modify fun s => s.addTuple edgeName #[typeName, typeName]
+      { atoms := #[atomId, altId], types := #[typeName, typeName] }
+  return atomId
+
+end
 
 /-- Walk an expression and produce a complete JsonDataInstance. -/
 def relationalize (e : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do

--- a/SpytialLean/Types.lean
+++ b/SpytialLean/Types.lean
@@ -4,11 +4,18 @@ namespace SpytialLean
 
 open Lean
 
-/-- A single atom (node) in the relational data instance. -/
+/-- A single atom (node) in the relational data instance.
+
+    `shared` is set when this atom is a subterm reached from more than one
+    parent (a DAG-shared node). The relationalizer deduplicates structurally
+    identical subterms by `Expr.hash`; the *second and later* visits flip this
+    flag on the already-emitted atom. spytial-core ignores the field today, so
+    it is purely informational (e.g. for distinct styling). -/
 structure JsonAtom where
   id : String
   type : String
   label : String
+  shared : Bool := false
   deriving ToJson, FromJson, Inhabited
 
 /-- A tuple in a relation — an ordered list of atom IDs with their types. -/

--- a/demos/FunctionFields.lean
+++ b/demos/FunctionFields.lean
@@ -6,6 +6,32 @@ open SpytialLean
 
 Structures with function-valued fields should decompose into mapping
 graphs rather than rendering as opaque lambda blobs.
+
+## Two views of a function: extensional vs intensional
+
+The relationalizer renders a `λ` two different ways depending on its domain:
+
+* **Extensional (what it computes).** When the domain is *finite and
+  enumerable* (`Bool`, `Fin n` for `n ≤ 20`, a zero-arity enum inductive), the
+  walker enumerates every input and emits one edge per input→output pair. The
+  diagram *is* the function's graph. This is the default and its shape is fixed.
+
+* **Intensional (how it is defined).** When the domain is *not* enumerable
+  (`Nat`, `List Nat`, …), enumerating is impossible, so instead of an opaque
+  leaf the walker decomposes the function *body* structurally — an AST view.
+  Entering the binder with `withLocalDecl`, it weak-head-reduces the body
+  (without unfolding definitions or `let`s) and emits:
+
+  - `if` / `dite` → an `if` node with `condition` / `then` / `else` edges,
+  - a pattern match (matcher auxiliary or `casesOn`) → a `match` node with a
+    `match` edge to the discriminant and one edge per branch, labeled by the
+    matching constructor,
+  - `let` → a `let` node with `let_value` / `let_body` edges,
+  - nested `λ` (multi-argument functions) → a `body` edge into the next binder,
+  - anything else (the bound variable, arithmetic on it, …) → a leaf labeled
+    with the pretty-printed surface expression (`n * 2`, `n > 10`).
+
+  Nested constructs nest: the `then` branch of an `if` can itself be an `if`.
 -/
 
 /-! ## Lightweight category theory structures -/
@@ -48,17 +74,19 @@ def myFunctor : SimpleFunctor threeStruct twoStruct :=
 structure Transform where
   f : Bool → Nat
 
-
--- TODO: I wonder if we can do something better about
--- the relationalization here. Like should it be , here's the body
--- of the transform with an "if" etc etc. Like an AST kind of thing?
 def myTransform : Transform :=
   { f := fun b => if b then 42 else 0 }
 
--- `f` is a function Bool → Nat — should enumerate true→42, false→0
+-- `f` has a finite domain (`Bool`) — extensional view: enumerate true→42,
+-- false→0. The body `if b then …` is NOT decomposed structurally here, because
+-- enumeration already shows exactly what the function computes.
 #spytial myTransform
 
-/-! ## Non-finite function field (graceful fallback) -/
+/-! ## Non-finite function field — structural (AST) decomposition
+
+`Nat` is not enumerable, so `process` cannot be shown extensionally. Rather than
+the opaque lambda blob this used to render, the body is now decomposed into an
+AST: `Processor.mk` → `process` → `λ n` → `body` → leaf `n + 1`. -/
 
 structure Processor where
   process : Nat → Nat
@@ -66,5 +94,55 @@ structure Processor where
 def myProcessor : Processor :=
   { process := fun n => n + 1 }
 
--- Nat is not finite — should show a labeled node, not an opaque blob
 #spytial myProcessor
+#spytial.datum myProcessor
+
+/-! ## Structural decomposition gallery (intensional view)
+
+The functions below all have non-enumerable domains, so each is shown as the
+structure of its definition. Use `#spytial.datum` to inspect the JSON: the
+`if` / `match` / `let` nodes and their edges are visible there. -/
+
+/-- An `if`-expression body. The decidable condition `n > 10` does not block the
+    `ite` — the walker emits an `if` node with `condition` / `then` / `else`
+    edges to the leaves `n > 10`, `n * 2`, `n + 1`. -/
+def classify : Nat → Nat := fun n => if n > 10 then n * 2 else n + 1
+
+#spytial classify
+#spytial.datum classify
+
+/-- Nested `if`: the `then` branch is itself an `if`, so the diagram nests one
+    `if` node inside another's `then` edge. -/
+def bucket : Nat → Nat := fun n =>
+  if n > 100 then 3 else if n > 10 then 2 else 1
+
+#spytial bucket
+#spytial.datum bucket
+
+/-- A pattern match over `List Nat` (a non-finite inductive payload). `match`
+    compiles to a matcher auxiliary; the walker emits a `match` node, a `match`
+    edge to the discriminant `l`, and `nil` / `cons` branch edges. -/
+def headOrZero : List Nat → Nat := fun l =>
+  match l with
+  | [] => 0
+  | x :: _ => x
+
+#spytial headOrZero
+#spytial.datum headOrZero
+
+/-- A two-argument function: nested lambdas decompose one binder per layer.
+    `λ a` → `body` → `λ b` → `body` → leaf `a + b`. -/
+def add2 : Nat → Nat → Nat := fun a b => a + b
+
+#spytial add2
+#spytial.datum add2
+
+/-- A `let`-binding survives reduction (zeta is disabled), so it surfaces as a
+    `let` node with `let_value` and `let_body` edges; the body here is itself an
+    `if`, which nests under `let_body`. -/
+def stepThenBranch : Nat → Nat := fun n =>
+  let y := n + 1
+  if y > 5 then y else 0
+
+#spytial stepThenBranch
+#spytial.datum stepThenBranch

--- a/demos/IndexedFamilies.lean
+++ b/demos/IndexedFamilies.lean
@@ -1,0 +1,36 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Indexed inductive families
+
+For an indexed inductive family the *index* carries information that the
+constructor name alone does not. A length-indexed `Vec` is the canonical case:
+`Vec.nil : Vec α 0` and a `Vec.cons … : Vec α 2` are different shapes, but their
+constructor atoms would be labeled just `nil` and `cons` — indistinguishable at
+a glance.
+
+When a constructor's inductive has `numIndices > 0`, the relationalizer reads
+the trailing index expressions off the value's *type* and appends them to the
+atom label, e.g. `cons : Vec 2`, `nil : Vec 0`. Only the label changes — the
+atom `type` field stays the head constant short name (`Vec`), so selectors that
+match on `type` are unaffected.
+-/
+
+/-! ## A length-indexed vector
+
+`Vec α n` is indexed by its length `n : Nat` (one index, `numIndices = 1`).
+-/
+
+inductive Vec (α : Type) : Nat → Type where
+  | nil : Vec α 0
+  | cons {n : Nat} (head : α) (tail : Vec α n) : Vec α (n + 1)
+
+/-- A 2-element vector, so its root has type `Vec Nat 2`. -/
+def v : Vec Nat 2 := .cons 10 (.cons 20 .nil)
+
+-- Labels carry the length: the root reads `cons : Vec 2`, the next `cons : Vec 1`,
+-- and the terminal `nil : Vec 0`. The `type` field stays `Vec` throughout.
+#spytial v
+
+#spytial.datum v

--- a/demos/Quotients.lean
+++ b/demos/Quotients.lean
@@ -1,0 +1,53 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Quotient types
+
+`Quot` is kernel-primitive: `Quot.mk` is registered as `.quotInfo`, not as a
+constructor (`.ctorInfo`), so the relationalizer's constructor dispatch misses
+it and a quotient value would otherwise render as an opaque leaf.
+
+The relationalizer special-cases applications headed by `Quot.mk` (and the
+`Quotient.mk` / `Quotient.mk'` const heads, which usually reduce to `Quot.mk`
+under whnf). Such a value becomes an atom labeled `⟦·⟧` — the equivalence-class
+brackets — whose representative is walked as a child connected by a relation
+named `repr`. The atom's `type` is the head name of the value's type (`Quot`,
+`Quotient`, or a user def if whnf keeps it).
+
+The diagram therefore reads: "this is an equivalence class `⟦·⟧`, and here
+(`repr`) is the underlying representative we chose."
+-/
+
+/-! ## `Quot.mk` with an explicit relation
+
+No `Setoid` instance or equivalence proof is needed for `Quot.mk` — it takes the
+relation and the representative directly. Here the relation is "same value mod
+3", and `5` is the representative.
+-/
+
+#spytial (Quot.mk (fun a b : Nat => a % 3 = b % 3) 5)
+
+-- The `repr` edge points at the `Nat` atom `5`.
+#spytial.datum (Quot.mk (fun a b : Nat => a % 3 = b % 3) 5)
+
+/-! ## `Quotient.mk` via a `Setoid`
+
+A `Setoid` on `Nat × Nat` whose relation `r a b := a.1 + b.2 = b.1 + a.2`
+identifies pairs with the same difference (the usual integer construction). The
+`iseqv` proof is short with `omega`.
+-/
+
+instance diffSetoid : Setoid (Nat × Nat) where
+  r a b := a.1 + b.2 = b.1 + a.2
+  iseqv := {
+    refl := fun a => by omega
+    symm := fun h => by omega
+    trans := fun h1 h2 => by omega
+  }
+
+-- `(3, 1)` represents the class of pairs with difference 2.
+#spytial (Quotient.mk diffSetoid (3, 1))
+
+-- The `repr` edge points at the `Prod` representative `(3, 1)`.
+#spytial.datum (Quotient.mk diffSetoid (3, 1))

--- a/demos/Sharing.lean
+++ b/demos/Sharing.lean
@@ -1,0 +1,48 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Sharing (DAG-shared subterms)
+
+When the same subterm appears in more than one position of a value, the
+relationalizer does *not* duplicate it: `walkExpr` deduplicates structurally
+identical subterms by `Expr.hash`, so the two positions point at a single atom.
+The result is a directed acyclic graph (DAG) rather than a tree.
+
+To make that sharing visible, the second-and-later visit to a subterm flips a
+`shared := true` flag on the already-emitted atom (see `JsonAtom.shared` and
+`WalkState.markShared`). The *first* atom reached for a subterm keeps
+`shared := false`; once another parent reaches the same subterm, the flag turns
+on. spytial-core ignores the field today, so it is purely informational (a
+consumer could, for instance, draw shared nodes with a dashed border).
+
+Below, `sub` is built once and placed in both children of `t`, so the single
+`node 7 nil nil` subtree is shared. Inspect the `#spytial.datum` output to see
+`"shared": true` on the shared atom (and on the shared `nil` leaf).
+-/
+
+/-! ## A small tree -/
+
+inductive Tree where
+  | nil : Tree
+  | node (key : Nat) (left : Tree) (right : Tree) : Tree
+  deriving Repr
+
+/-- A subtree built once and reused in two positions of `t`. -/
+def sub : Tree := .node 7 .nil .nil
+
+/-- `t` places `sub` in both the left and right child, so `sub` is shared. -/
+def t : Tree := .node 1 sub sub
+
+-- The diagram shows a single `node 7` atom with two incoming edges (a DAG).
+#spytial t
+
+/-! ## Inspecting the `shared` flag
+
+The `#spytial.datum` command prints the JSON data instance. Look for the atom
+corresponding to `node 7 nil nil`: it carries `"shared": true`, because it was
+reached from both the `left` and the `right` edge of the root. The `nil` leaf
+under it is likewise shared.
+-/
+
+#spytial.datum t

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -71,7 +71,8 @@ lean_lib SpytialLean where
 
 lean_lib Demos where
   srcDir := "demos"
-  roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer]
+  roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
+             `Sharing, `Quotients, `IndexedFamilies]
   needs := #[widgetJsAll]
 
 require proofwidgets from


### PR DESCRIPTION
## Summary

**PR 1 of 3** in a stacked series implementing the open-issue roadmap. This PR covers **term-shape relationalizer features** — how a Lean `Expr` is walked into atoms and relations. Design decisions are recorded in [`PLAN.md`](PLAN.md).

| Issue | Feature | How |
|-------|---------|-----|
| [#22](https://github.com/sidprasad/spytial-lean/issues/22) | **DAG-shared subterms** | `JsonAtom.shared` flag, set on the second-and-later visit to a hash-cached subterm. Visible in `#spytial.datum`; widget styling deferred to spytial-core (the data already carries the flag). |
| [#9](https://github.com/sidprasad/spytial-lean/issues/9) | **Quotient types** | `Quot.mk`/`Quotient.mk` applications become a `⟦·⟧` atom with a `repr` edge to the representative, instead of an opaque leaf. |
| [#21](https://github.com/sidprasad/spytial-lean/issues/21) | **Indexed families** | Constructor atoms of indexed inductives carry their type indices in the label (`cons : Vec 2`). The `type` field stays stable so selectors are unaffected. |
| [#13](https://github.com/sidprasad/spytial-lean/issues/13) | **Structural function bodies** | For non-finite domains (where we used to emit a leaf), decompose the body: `ite`/`dite` → `if` node, matcher/`casesOn` → `match` node with per-constructor branches, `letE` → `let` node, nested lambdas peel one binder per layer. Finite-domain enumeration is unchanged. |

## Design notes
- **Selector stability is sacrosanct** — the atom `type` field is the public selector API, so these features enrich *labels* only (indices, quotient markers) and never change `type` strings or relation names.
- **Strict-improvement rule** — opaque leaves may decompose further; anything that already decomposed keeps its default output shape.

## Demos
New runnable demos: `Sharing`, `Quotients`, `IndexedFamilies`, plus structural-decomposition examples added to `FunctionFields`.

## Verification
`lake build` + `lake build Demos` green. The `#13` demos elaborate every new `walkBody`/`walkMatch`/`walkCasesOn` path.

> **Stack:** base `main`. Followed by PR 2 (commands & spec ops) and PR 3 (limits & proof-state). A latent panic-guard for an under-applied matcher in `walkMatch` lands in PR 3's review-hardening commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
