### PR TITLE
Commands & spec ops: #spytial.enumerate, .notationLabel, type-class inheritance (#8 #24 #2)

### DIFF
--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -72,13 +72,18 @@ def elabSpytialCmd : CommandElab := fun
       let e ← Term.elabTerm t none
       Term.synthesizeSyntheticMVarsNoPostponing
       let e ← instantiateMVars e
-      let di ← relationalize e
-      -- Determine spec: explicit `with [...]` > type attribute > none
-      let yaml ← match spec? with
+      -- Evaluate the spec FIRST: relationalizer-side ops (`.notationLabel`) must
+      -- influence the walk, so they are partitioned into `WalkConfig.collapseTypes`
+      -- while the remaining (widget) ops become the YAML.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupTypeSpec e
+          pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => do
+          -- Type-attached specs are stored as YAML and cannot carry `.notationLabel`.
+          pure ({ : WalkConfig }, ← lookupTypeSpec e)
+      let di ← relationalize e cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -117,6 +122,12 @@ def elabSpytialSpecCmd : CommandElab := fun
       throwError s!"unknown declaration '{declName}'"
     let yamlStr ← liftTermElabM do
       let spec ← evalSpytialSpec specTerm
+      -- Type-attached specs are stored as YAML in the environment extension, so
+      -- relationalizer-side ops (`.notationLabel`) cannot round-trip through them
+      -- (PLAN.md #24). Rather than silently drop them, reject them clearly.
+      unless spec.collapseTypes.isEmpty do
+        throwError "'.notationLabel' is not supported in type-attached specs yet; \
+          use it in a `with [...]` block"
       return SpytialSpec.toYaml spec
     liftCoreM <| setSpytialSpec declName yamlStr
   | stx => throwError "Unexpected syntax {stx}."
@@ -153,7 +164,12 @@ unsafe def elabSpytialRelationalizerCmd : CommandElab := fun
 /-! ## Debugging commands -/
 
 /-- `#spytial.spec <term> with [<ops>]` prints the generated YAML spec.
-    Useful for debugging whether the spec is what you expect. -/
+    Useful for debugging whether the spec is what you expect.
+
+    Relationalizer-side ops (e.g. `.notationLabel`) are NOT YAML — they configure
+    the walk, not the widget — so they are stripped before printing (just as the
+    `#spytial` elaborator strips them before sending YAML to spytial-core). Their
+    effect shows up in `#spytial.datum`/the diagram, not here. -/
 syntax (name := spytialSpecDebug) "#spytial.spec " term " with " term : command
 
 @[command_elab spytialSpecDebug]
@@ -161,7 +177,7 @@ def elabSpytialSpecDebug : CommandElab := fun
   | `(#spytial.spec $_t:term with $specTerm:term) => do
     let yamlStr ← liftTermElabM do
       let spec ← evalSpytialSpec specTerm
-      return SpytialSpec.toYaml spec
+      return SpytialSpec.toYaml spec.withoutRelationalizerOps
     logInfo m!"{yamlStr}"
   | stx => throwError "Unexpected syntax {stx}."
 
@@ -198,12 +214,15 @@ def elabSpytialProofCmd : CommandElab := fun
       let e ← Term.elabTerm t none
       Term.synthesizeSyntheticMVarsNoPostponing
       let e ← instantiateMVars e
-      let di ← relationalize e { filterProofs := false }
-      let yaml ← match spec? with
+      -- Evaluate the spec first so `.notationLabel` ops can configure the walk
+      -- (collapsed types) while proof mode keeps `filterProofs := false`.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupTypeSpec e
+          pure ({ filterProofs := false, collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => pure ({ filterProofs := false : WalkConfig }, ← lookupTypeSpec e)
+      let di ← relationalize e cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -259,10 +278,11 @@ private def lookupSpecForType (ty : Expr) : MetaM (Option String) := do
 
 /-- Enumerate all inhabitants of `ty` (via `tryEnumerateDomain`) and walk them
     into a single shared `JsonDataInstance`. Throws a clear error naming the type
-    if it is not enumerable. -/
-private def enumerateType (ty : Expr) : MetaM JsonDataInstance := do
+    if it is not enumerable. `cfg` forwards walker configuration (e.g. the
+    `.notationLabel` collapse set) to `relationalizeAll`. -/
+private def enumerateType (ty : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do
   match ← tryEnumerateDomain ty with
-  | some elems => relationalizeAll (elems.map (·.2))
+  | some elems => relationalizeAll (elems.map (·.2)) cfg
   | none =>
     throwError "#spytial.enumerate cannot enumerate '{ty}'. Enumerable types are: \
       Bool, Fin n (n ≤ 20), and inductive types whose constructors all take no arguments."
@@ -292,13 +312,15 @@ def elabSpytialEnumerateCmd : CommandElab := fun
   | stx@`(#spytial.enumerate $t:term $[with $spec?]?) => do
     let (dataInstance, specYaml) ← liftTermElabM do
       let ty ← elabAsType t
-      let di ← enumerateType ty
-      -- Determine spec: explicit `with [...]` > spec attached to the type > none
-      let yaml ← match spec? with
+      -- Evaluate the spec first so `.notationLabel` ops configure the enumeration
+      -- walk (collapsed types) while the remaining ops become the YAML.
+      let (cfg, yaml) ← match spec? with
         | some specTerm => do
           let spec ← evalSpytialSpec specTerm
-          pure (some (SpytialSpec.toYaml spec))
-        | none => lookupSpecForType ty
+          pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+                some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+        | none => pure ({ : WalkConfig }, ← lookupSpecForType ty)
+      let di ← enumerateType ty cfg
       return (di, yaml)
 
     let props : Json := Json.mkObj <|
@@ -354,13 +376,15 @@ def elabSpytialTactic : Tactic := fun stx => do
     let e ← Term.elabTerm t none
     Term.synthesizeSyntheticMVarsNoPostponing
     let e ← instantiateMVars e
-    let di ← relationalize e
-    let yaml ← if specOpt.isNone then
-        lookupTypeSpec e
-      else
+    -- Evaluate the spec first so `.notationLabel` ops configure the walk.
+    let (cfg, yaml) ← if specOpt.isNone then
+        pure ({ : WalkConfig }, ← lookupTypeSpec e)
+      else do
         let specTerm := specOpt[1]!
         let spec ← evalSpytialSpec specTerm
-        pure (some (SpytialSpec.toYaml spec))
+        pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+              some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+    let di ← relationalize e cfg
 
     let props : Json := Json.mkObj <|
       [("dataInstance", toJson di)] ++
@@ -385,13 +409,16 @@ def elabSpytialProofTactic : Tactic := fun stx => do
     let e ← Term.elabTerm t none
     Term.synthesizeSyntheticMVarsNoPostponing
     let e ← instantiateMVars e
-    let di ← relationalize e { filterProofs := false }
-    let yaml ← if specOpt.isNone then
-        lookupTypeSpec e
-      else
+    -- Evaluate the spec first so `.notationLabel` ops configure the walk;
+    -- proof mode keeps `filterProofs := false`.
+    let (cfg, yaml) ← if specOpt.isNone then
+        pure ({ filterProofs := false : WalkConfig }, ← lookupTypeSpec e)
+      else do
         let specTerm := specOpt[1]!
         let spec ← evalSpytialSpec specTerm
-        pure (some (SpytialSpec.toYaml spec))
+        pure ({ filterProofs := false, collapseTypes := spec.collapseTypes : WalkConfig },
+              some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+    let di ← relationalize e cfg
 
     let props : Json := Json.mkObj <|
       [("dataInstance", toJson di)] ++

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -234,6 +234,101 @@ def elabSpytialProofDatumDebug : CommandElab := fun
     logInfo m!"{json.pretty}"
   | stx => throwError "Unexpected syntax {stx}."
 
+/-! ## Enumeration -/
+
+/-- Elaborate `t` and check that it denotes a *type* (its inferred type is a
+    sort). Returns the elaborated type expression. Errors clearly if the user
+    passed a value instead of a type. -/
+private def elabAsType (t : Syntax) : TermElabM Expr := do
+  let e ← Term.elabTerm t none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let e ← instantiateMVars e
+  let eTy ← Meta.inferType e
+  unless (← Meta.whnf eTy).isSort do
+    throwError "#spytial.enumerate expects a type, but '{e}' is a value of type '{eTy}'. \
+      Pass a type such as `Bool`, `Fin 5`, or a zero-arity enum inductive."
+  return e
+
+/-- Look up a Spytial spec attached to a type *by the type itself* (not by the
+    type of a value). Used by `#spytial.enumerate`, whose argument is already a
+    type expression. -/
+private def lookupSpecForType (ty : Expr) : MetaM (Option String) := do
+  match (← whnf ty).getAppFn with
+  | .const n _ => return getSpytialSpec? (← getEnv) n
+  | _ => return none
+
+/-- Enumerate all inhabitants of `ty` (via `tryEnumerateDomain`) and walk them
+    into a single shared `JsonDataInstance`. Throws a clear error naming the type
+    if it is not enumerable. -/
+private def enumerateType (ty : Expr) : MetaM JsonDataInstance := do
+  match ← tryEnumerateDomain ty with
+  | some elems => relationalizeAll (elems.map (·.2))
+  | none =>
+    throwError "#spytial.enumerate cannot enumerate '{ty}'. Enumerable types are: \
+      Bool, Fin n (n ≤ 20), and inductive types whose constructors all take no arguments."
+
+/-- `#spytial.enumerate <Type>` enumerates ALL inhabitants of a finite type and
+    renders the entire population in a single spatial diagram.
+
+    Enumerable types are `Bool`, `Fin n` (for `n ≤ 20`), and inductive types
+    whose constructors all take no arguments. Every inhabitant is walked into one
+    shared diagram, so references between them (e.g. a function field pointing at
+    an enumerated element) unify.
+
+    ```
+    inductive Color | red | green | blue
+    #spytial.enumerate Color
+    #spytial.enumerate Bool
+    #spytial.enumerate (Fin 5)
+    ```
+
+    Use `with [...]` to specify layout operations. If the enumerated type has an
+    attached spec (via `spytial_spec`), it is used as the default.
+-/
+syntax (name := spytialEnumerateCmd) "#spytial.enumerate " term (" with " term)? : command
+
+@[command_elab spytialEnumerateCmd]
+def elabSpytialEnumerateCmd : CommandElab := fun
+  | stx@`(#spytial.enumerate $t:term $[with $spec?]?) => do
+    let (dataInstance, specYaml) ← liftTermElabM do
+      let ty ← elabAsType t
+      let di ← enumerateType ty
+      -- Determine spec: explicit `with [...]` > spec attached to the type > none
+      let yaml ← match spec? with
+        | some specTerm => do
+          let spec ← evalSpytialSpec specTerm
+          pure (some (SpytialSpec.toYaml spec))
+        | none => lookupSpecForType ty
+      return (di, yaml)
+
+    let props : Json := Json.mkObj <|
+      [("dataInstance", toJson dataInstance)] ++
+      match specYaml with
+      | some s => [("cndSpec", toJson s)]
+      | none => []
+
+    liftCoreM <| savePanelWidgetInfo
+      SpytialWidget.javascriptHash
+      (return props)
+      stx
+
+  | stx => throwError "Unexpected syntax {stx}."
+
+/-- `#spytial.enumerate.datum <Type>` prints the JSON data instance produced by
+    enumerating all inhabitants of a finite type. The debugging counterpart of
+    `#spytial.enumerate`, mirroring `#spytial.datum`. -/
+syntax (name := spytialEnumerateDatumDebug) "#spytial.enumerate.datum " term : command
+
+@[command_elab spytialEnumerateDatumDebug]
+def elabSpytialEnumerateDatumDebug : CommandElab := fun
+  | `(#spytial.enumerate.datum $t:term) => do
+    let dataInstance ← liftTermElabM do
+      let ty ← elabAsType t
+      enumerateType ty
+    let json := toJson dataInstance
+    logInfo m!"{json.pretty}"
+  | stx => throwError "Unexpected syntax {stx}."
+
 /-! ## spytial tactic -/
 
 open Tactic in

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -181,6 +181,30 @@ def elabSpytialSpecDebug : CommandElab := fun
     logInfo m!"{yamlStr}"
   | stx => throwError "Unexpected syntax {stx}."
 
+/-- `#spytial.typespec <term>` prints the YAML spec that `lookupTypeSpec` resolves
+    for the term's head type (via `spytial_spec`), or `none` if no spec applies.
+
+    This is the spec lookup itself — the same lookup `#spytial` performs when no
+    explicit `with [...]` block is given. For structures and type classes (which
+    *are* structures in Lean 4) it walks the parent chain and composes specs
+    root-first, so a child inherits a parent's `spytial_spec` (PLAN.md #2). Use it
+    to confirm that a parent spec is found and merged for a child value — the
+    YAML it prints contains the lines from every spec in the chain. -/
+syntax (name := spytialTypeSpecDebug) "#spytial.typespec " term : command
+
+@[command_elab spytialTypeSpecDebug]
+def elabSpytialTypeSpecDebug : CommandElab := fun
+  | `(#spytial.typespec $t:term) => do
+    let result ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      lookupTypeSpec e
+    match result with
+    | some yaml => logInfo m!"{yaml}"
+    | none      => logInfo m!"none"
+  | stx => throwError "Unexpected syntax {stx}."
+
 /-- `#spytial.datum <term>` prints the generated JSON data instance.
     Shows what atoms and relations the relationalizer produces. -/
 syntax (name := spytialDatumDebug) "#spytial.datum " term : command

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -574,4 +574,20 @@ def relationalize (e : Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance :
   let (_, state) ← walkExpr cfg e |>.run {}
   return state.toDataInstance
 
+/-- Walk every expression in `es` through a *single shared* `WalkState`, then
+    produce one combined `JsonDataInstance`.
+
+    Folding `walkExpr` over a single state (rather than relationalizing each
+    expression independently and merging) means the per-expr `seen` cache is
+    shared: structurally identical subterms across the whole population collapse
+    to the same atom id, so e.g. a function field pointing at an enumerated
+    element unifies with that element. Used by `#spytial.enumerate` to render all
+    inhabitants of a finite type in one diagram. -/
+def relationalizeAll (es : Array Expr) (cfg : WalkConfig := {}) : MetaM JsonDataInstance := do
+  let walkAll : StateT WalkState MetaM Unit := do
+    for e in es do
+      let _ ← walkExpr cfg e
+  let (_, state) ← walkAll.run {}
+  return state.toDataInstance
+
 end SpytialLean

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -48,6 +48,11 @@ def WalkState.toDataInstance (s : WalkState) : JsonDataInstance :=
 structure WalkConfig where
   /-- When true, skip Prop-typed fields (data mode). When false, show them (proof mode). -/
   filterProofs : Bool := true
+  /-- Type-head short names whose values should be collapsed to a single atom
+      labeled with their surface notation, instead of being decomposed. Populated
+      from `.notationLabel` spec ops (see `SpytialSpec.collapseTypes`). E.g.
+      `["List"]` renders `[1, 2, 3]` as one atom rather than a cons chain. -/
+  collapseTypes : List String := []
 
 /-- Check if an expression is a proof or type (erased at runtime). -/
 def isProofArg (e : Expr) : MetaM Bool := do
@@ -205,8 +210,22 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
   let s := s.markSeen hash atomId
   set s
 
-  -- Check for custom relationalizer before default dispatch
+  -- Notation collapse: if this value's type-head short name was opted in via a
+  -- `.notationLabel` spec op, emit ONE atom labeled with the surface notation of
+  -- the *original* (pre-whnf) expression and stop. `eOrig` is what the delaborator
+  -- resugars (so `[1, 2, 3]` survives instead of the cons chain). This runs before
+  -- the custom-relationalizer dispatch and the main match so neither decomposes it.
   let tyWhnfForLookup ← Meta.whnf ty
+  let typeHeadShortName : Option String := match tyWhnfForLookup.getAppFn with
+    | .const n _ => some (shortName n)
+    | _ => none
+  if let some tn := typeHeadShortName then
+    if cfg.collapseTypes.contains tn then
+      let label ← ppLabel eOrig
+      modify fun s => s.addAtom { id := atomId, type := tn, label := label }
+      return atomId
+
+  -- Check for custom relationalizer before default dispatch
   if let .const typeConstName _ := tyWhnfForLookup.getAppFn then
     if let some relFn ← getSpytialRelationalizer? typeConstName then
       return ← relFn eOrig (walkExpr cfg)

--- a/SpytialLean/Spec.lean
+++ b/SpytialLean/Spec.lean
@@ -44,6 +44,8 @@ inductive SpytialOp where
   | inferredEdge (name : String) (selector : String)
       (color : String := "#000000") (style : EdgeStyle := .solid)
   | flag (name : String)
+  -- Relationalizer-side ops (NOT widget directives, NOT constraints; see below)
+  | notationLabel (selector : String)
   deriving Repr, Inhabited
 
 /-- A list of Spytial operations forming a complete layout specification. -/
@@ -135,16 +137,54 @@ private def directiveToYaml : SpytialOp → String
     s!"  - size: \{selector: \"{sel}\", width: {w}, height: {h}}"
   | _ => ""
 
-/-- Convert a `SpytialSpec` to a YAML string consumable by `parseLayoutSpec`. -/
+/-- Convert a `SpytialSpec` to a YAML string consumable by `parseLayoutSpec`.
+
+    Relationalizer-side ops (e.g. `.notationLabel`) are not widget directives and
+    are not constraints; their `*ToYaml` arms return `""`. Those empty strings are
+    filtered out before joining, so a relationalizer-only op (or any unhandled op
+    reaching a no-match arm) cannot inject a blank YAML list entry. Such ops should
+    be stripped via `SpytialSpec.withoutRelationalizerOps` before calling this; the
+    filter is a defensive backstop only. -/
 def SpytialSpec.toYaml (spec : SpytialSpec) : String :=
   let constraints := spec.filter SpytialOp.isConstraint
   let directives := spec.filter (! SpytialOp.isConstraint ·)
   let parts : List String := []
   let parts := if constraints.isEmpty then parts else
-    parts ++ ["constraints:"] ++ constraints.map constraintToYaml
+    parts ++ ["constraints:"] ++ (constraints.map constraintToYaml).filter (· != "")
   let parts := if directives.isEmpty then parts else
-    parts ++ ["directives:"] ++ directives.map directiveToYaml
+    parts ++ ["directives:"] ++ (directives.map directiveToYaml).filter (· != "")
   "\n".intercalate parts
+
+/-! ## Relationalizer-side ops
+
+Some ops configure the *relationalizer* (how Lean terms are walked into atoms and
+relations) rather than the *widget* (how the resulting data instance is laid out).
+`.notationLabel` is the first such op: it tells the walker to collapse values of a
+given type to a single atom labeled with their surface notation. These ops are
+neither constraints nor directives — they must never reach the YAML, which is what
+spytial-core's `parseLayoutSpec` consumes. The command elaborators partition them
+out of the spec (`collapseTypes` feeds `WalkConfig`; `withoutRelationalizerOps`
+yields the remainder for `toYaml`). -/
+
+/-- Is this a relationalizer-side op (configures the walk, not the widget)? -/
+def SpytialOp.isRelationalizerOp : SpytialOp → Bool
+  | .notationLabel .. => true
+  | _ => false
+
+/-- The selectors of all `.notationLabel` ops in `spec` — type-head short names
+    whose values should be collapsed to a single notation-labeled atom. These
+    configure the *relationalizer* (fed into `WalkConfig.collapseTypes`), not the
+    widget; they never appear in the YAML. -/
+def SpytialSpec.collapseTypes (spec : SpytialSpec) : List String :=
+  spec.filterMap fun
+    | .notationLabel sel => some sel
+    | _ => none
+
+/-- Drop all relationalizer-side ops (e.g. `.notationLabel`) from `spec`, leaving
+    only the constraint/directive ops that belong in the YAML. The elaborators call
+    this before `toYaml` so relationalizer-only ops never reach spytial-core. -/
+def SpytialSpec.withoutRelationalizerOps (spec : SpytialSpec) : SpytialSpec :=
+  spec.filter (! SpytialOp.isRelationalizerOp ·)
 
 /-- Extract constraint and directive lines from a YAML spec string.
     Returns `(constraintLines, directiveLines)`. -/

--- a/demos/Enumeration.lean
+++ b/demos/Enumeration.lean
@@ -1,0 +1,98 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Enumeration
+
+`#spytial.enumerate <Type>` enumerates ALL inhabitants of a finite type and
+renders the entire population in a single spatial diagram.
+
+A type is enumerable when `tryEnumerateDomain` can list its elements:
+
+* `Bool` — `false`, `true`,
+* `Fin n` for `n ≤ 20` — `0 … n-1`,
+* an inductive type whose constructors *all* take no arguments (a plain enum).
+
+There is deliberately **no `Fintype` support**: that lives in Mathlib, and the
+core library and default demos stay Mathlib-free. Non-enumerable types get a
+clear error naming what is supported (see the failing case at the bottom).
+
+Every inhabitant is walked into ONE shared diagram, so structurally identical
+subterms across the population unify (the relationalizer's `seen` cache is
+shared across the whole enumeration).
+-/
+
+/-! ## A custom enum -/
+
+/-- A three-element enumeration. All constructors take no arguments, so the type
+    is enumerable. -/
+inductive Three where
+  | a | b | c
+  deriving Repr
+
+-- Renders three atoms labeled `a`, `b`, `c` in a single diagram.
+#spytial.enumerate Three
+
+-- Inspect the JSON: exactly three atoms, no relations.
+#spytial.enumerate.datum Three
+
+/-! ## Built-in finite types -/
+
+-- `Bool` enumerates to `false`, `true`.
+#spytial.enumerate Bool
+
+-- `Fin 5` enumerates to `0, 1, 2, 3, 4`.
+#spytial.enumerate (Fin 5)
+
+#spytial.enumerate.datum Bool
+#spytial.enumerate.datum (Fin 5)
+
+/-! ## Enumerating a mapping — `#spytial f` already does this
+
+The issue's motivating example is a function on a finite domain. A natural ask
+is a `#spytial.map f` command that draws the function's graph. It is
+*unnecessary*: `#spytial f` ALREADY enumerates the mapping. When the
+relationalizer reaches a `λ` whose domain is enumerable, it takes the
+extensional view — it enumerates every input and emits one input→output edge.
+So plain `#spytial f` on a `Three → Three` shows the graph `a→b`, `b→c`, `c→a`
+directly, and a separate `#spytial.map` variant would be redundant. -/
+
+/-- The issue's motivating map: a cyclic permutation of `Three`. -/
+def f : Three → Three
+  | .a => .b
+  | .b => .c
+  | .c => .a
+
+-- No `#spytial.map` needed: the lambda's finite domain is enumerated here,
+-- producing the mapping graph a→b, b→c, c→a.
+#spytial f
+#spytial.datum f
+
+/-! ## Spec lookup
+
+A spec attached to the enumerated type (via `spytial_spec`) is used as the
+default, just like `#spytial` looks up the spec of a value's type. An explicit
+`with [...]` overrides it. -/
+
+spytial_spec Three [
+  .atomColor (selector := "Three") (value := "#4CAF50")
+]
+
+-- Uses the spec attached to `Three`.
+#spytial.enumerate Three
+
+-- Explicit `with [...]` overrides the attached spec.
+#spytial.enumerate Three with [
+  .atomColor (selector := "Three") (value := "#2196F3")
+]
+
+/-! ## Failing case — non-enumerable type
+
+`Nat` has infinitely many inhabitants, so it is not enumerable. Uncommenting the
+line below produces:
+
+  #spytial.enumerate cannot enumerate 'Nat'. Enumerable types are: Bool,
+  Fin n (n ≤ 20), and inductive types whose constructors all take no arguments.
+-/
+
+-- #spytial.enumerate Nat -- error: not enumerable

--- a/demos/NotationLabels.lean
+++ b/demos/NotationLabels.lean
@@ -1,0 +1,90 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Notation-aware atom labels (`.notationLabel`)
+
+Lean elaborates notation away before the relationalizer runs, so `[1, 2, 3]`
+arrives as a `List.cons 1 (List.cons 2 (List.cons 3 List.nil))` term and renders
+as a four-atom cons chain (three `cons` nodes plus the `nil` terminator, with
+`head`/`tail` edges). That faithful structural view is often exactly what you
+want — but sometimes you would rather see the *surface syntax*.
+
+The `.notationLabel` spec op is an opt-in that collapses every value of a chosen
+type to a **single** atom labeled with the pretty-printed (delaborator-resugared)
+expression — `[1, 2, 3]`, `(1, 2)`, etc. It is a *relationalizer-side* op: it
+configures how terms are walked, not how the diagram is laid out, so it never
+appears in the YAML sent to spytial-core (per the project's partitioning rule).
+
+Selectors here use the **type-HEAD short name**, not the full applied type:
+write `.notationLabel (selector := "List")`, not `"List Nat"`. The head name is
+the same string that fills an atom's `type` field (`List`, `Prod`, …).
+
+Limitation: `.notationLabel` works in `with [...]` blocks only. Type-attached
+specs (`spytial_spec`) are stored as YAML and cannot carry it yet; writing one
+there is a clear error rather than a silent drop.
+-/
+
+/-! ## A list: cons chain vs. one collapsed atom
+
+Plain `#spytial` shows the structural cons chain: atoms `cons`, `cons`, `cons`,
+`nil` (all typed `List`) with `head` edges to the `Nat` leaves `1`, `2`, `3` and
+`tail` edges chaining them together — four `List` atoms in total.
+-/
+
+#spytial ([1, 2, 3] : List Nat)
+
+/-! With `.notationLabel (selector := "List")` the same value becomes ONE atom,
+    typed `List`, labeled `[1, 2, 3]`, with no relations. -/
+
+#spytial ([1, 2, 3] : List Nat) with [.notationLabel (selector := "List")]
+
+-- Expected collapsed data instance (one atom, no edges):
+--   atoms:     [{ id: atom_0, type: "List", label: "[1, 2, 3]" }]
+--   relations: []
+-- (The datum debug commands take no `with` block, so the collapsed JSON is noted
+--  here rather than printed; `#spytial.datum` below shows the un-collapsed chain.)
+#spytial.datum ([1, 2, 3] : List Nat)
+
+/-! ## Nested: the field collapses, the parent decomposes
+
+In `("xs", [1, 2]) : String × List Nat` the `Prod` is NOT in the collapse set, so
+it decomposes as usual into `mk` with `fst` / `snd` edges. The `snd` field is a
+`List`, which IS collapsed: it becomes a single `[1, 2]` atom instead of a cons
+chain. So collapse is per-type and applies wherever a matching value appears,
+however deeply nested.
+-/
+
+#spytial (("xs", [1, 2]) : String × List Nat) with [.notationLabel (selector := "List")]
+
+-- Expected: `Prod` atom `mk`; edge `fst` → String atom `"xs"`; edge `snd` → a
+-- single `List` atom labeled `[1, 2]`.
+
+/-! ## Collapsing `Prod` itself
+
+The type head for a pair is `Prod`, so `.notationLabel (selector := "Prod")`
+renders `(1, 2)` as one atom labeled `(1, 2)`.
+-/
+
+#spytial ((1, 2) : Nat × Nat) with [.notationLabel (selector := "Prod")]
+
+-- Expected: a single `Prod` atom labeled `(1, 2)`, no relations.
+
+/-! ## Combining with widget ops
+
+`.notationLabel` coexists with ordinary layout/styling ops in the same block: the
+relationalizer-side op configures the walk while the rest become the YAML. Here
+the list collapses to one atom AND that atom is colored.
+-/
+
+#spytial ([1, 2, 3] : List Nat) with [
+  .notationLabel (selector := "List"),
+  .atomColor (selector := "List") (value := "#0066ff")
+]
+
+-- `#spytial.spec` confirms the YAML carries ONLY the widget op — the
+-- `.notationLabel` op is stripped (it is not YAML):
+#spytial.spec ([1, 2, 3] : List Nat) with [
+  .notationLabel (selector := "List"),
+  .atomColor (selector := "List") (value := "#0066ff")
+]

--- a/demos/SpecInheritance.lean
+++ b/demos/SpecInheritance.lean
@@ -1,0 +1,173 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Spec inheritance through structure parent chains (issue #2)
+
+A `spytial_spec` attached to a type is the default layout used when a value of
+that type is visualized. This demo verifies — empirically, in the build log —
+that the spec lookup walks the *structure parent chain*, so a value of a derived
+type inherits the spec attached to its base type.
+
+The mechanism under test is `lookupTypeSpec` in `SpytialLean/Command.lean`. For a
+value whose head type is a structure, it reads the parent structures
+(`getAllParentStructures`, C3 linearization) and composes their specs root-first,
+merging the YAML (`mergeSpecYamls`). Because Lean 4 *classes are structures*, the
+exact same path makes `class B extends A` inherit `A`'s spec — no extra code.
+
+The `#spytial.typespec <term>` debug command prints precisely the YAML that
+`lookupTypeSpec` resolves (or `none`). It is the cleanest assertion of inheritance:
+if the parent chain works, the printed YAML contains lines from *every* spec in the
+chain. Each spec below uses a recognizable `.atomColor` value so you can read off,
+from the merged YAML, which specs were composed.
+
+Run `lake build Demos` and read the `#spytial.typespec` info diagnostics in the
+build log to see the merged YAML for each case.
+-/
+
+/-! ## 1. Baseline: plain structure extension
+
+`Derived extends Base`. A spec on `Base` should apply to a `Derived` value, and a
+spec on `Derived` itself should compose with it (root-first: Base, then Derived).
+-/
+
+structure Base where
+  tag : Nat
+  deriving Repr
+
+structure Derived extends Base where
+  extra : Nat
+  deriving Repr
+
+-- Distinct, recognizable colors so the merged YAML is self-documenting.
+spytial_spec Base [
+  .atomColor (selector := "Base") (value := "#336699")
+]
+
+spytial_spec Derived [
+  .atomColor (selector := "Derived") (value := "#cc3300")
+]
+
+def aDerived : Derived := { tag := 1, extra := 2 }
+
+-- The diagram uses the inherited+own spec as its default.
+#spytial aDerived
+
+-- Spec lookup, asserted in the build log. Expect the MERGED YAML containing both
+-- the Base color (#336699) and the Derived color (#cc3300), Base-first.
+#spytial.typespec aDerived
+
+-- A bare `Base` value resolves only Base's spec.
+def aBase : Base := { tag := 0 }
+#spytial.typespec aBase
+
+/-! ## 2. Type classes: `class Dog extends Animal`
+
+Lean 4 classes are structures, so this exercises the very same parent-chain path.
+A spec on the parent class `Animal` must apply to a `Dog` instance value.
+-/
+
+class Animal (α : Type) where
+  legs : Nat
+
+class Dog (α : Type) extends Animal α where
+  goodBoy : Bool
+
+instance : Animal Unit where
+  legs := 4
+
+instance : Dog Unit where
+  legs := 4
+  goodBoy := true
+
+spytial_spec Animal [
+  .atomColor (selector := "Animal") (value := "#118811")
+]
+
+spytial_spec Dog [
+  .atomColor (selector := "Dog") (value := "#8811cc")
+]
+
+-- A `Dog` instance value. `inferInstance` synthesizes the registered instance.
+def aDog : Dog Unit := inferInstance
+
+#spytial aDog
+
+-- Expect the MERGED YAML: Animal color (#118811) then Dog color (#8811cc).
+-- This is the key result: a parent *class*'s spec reaches a child instance.
+#spytial.typespec aDog
+
+-- An `Animal` instance resolves only Animal's spec.
+def anAnimal : Animal Unit := inferInstance
+#spytial.typespec anAnimal
+
+/-! ## 3. Deeper chain (3 levels): C3 linearization order
+
+`Vehicle ← Car ← SportsCar`. The composed YAML must list the specs root-first
+(Vehicle, Car, SportsCar), demonstrating the C3 linearization order produced by
+`getAllParentStructures` (reversed to root-first, self last).
+-/
+
+structure Vehicle where
+  wheels : Nat
+  deriving Repr
+
+structure Car extends Vehicle where
+  doors : Nat
+  deriving Repr
+
+structure SportsCar extends Car where
+  topSpeed : Nat
+  deriving Repr
+
+spytial_spec Vehicle [
+  .atomColor (selector := "Vehicle") (value := "#111111")
+]
+
+spytial_spec Car [
+  .atomColor (selector := "Car") (value := "#222222")
+]
+
+spytial_spec SportsCar [
+  .atomColor (selector := "SportsCar") (value := "#333333")
+]
+
+def aSportsCar : SportsCar := { wheels := 4, doors := 2, topSpeed := 300 }
+
+#spytial aSportsCar
+
+-- Expect the MERGED YAML in root-first order:
+--   Vehicle (#111111), Car (#222222), SportsCar (#333333).
+#spytial.typespec aSportsCar
+
+/-! ## Deferred cases (issue #2 stays open)
+
+The issue also asks for three further forms of spec inheritance. All three are
+deferred with rationale recorded in `PLAN.md` (the "#2" section); see
+<https://github.com/sidprasad/spytial-lean/issues/2>. They are NOT implemented
+here:
+
+1. **Explicit `spytial_spec X extends Y` syntax** for plain inductives that are
+   *not* connected by a structure parent chain (e.g. an `RBNode` that should
+   reuse a `Tree` spec). New surface syntax for a niche need — wait for demand.
+
+2. **Per-instantiation specs** (`List Nat` distinct from `List`). The spec store
+   is keyed by `Name`, so it cannot today distinguish a type by its arguments.
+   Keying by type *expression* is a storage-format migration — follow-up.
+
+3. **Subtype inheritance.** A value of `{x : Nat // x > 0}` is headed by
+   `Subtype` and is a `Subtype.mk` pair; silently inheriting `Nat`'s spec would
+   mislabel the wrapper atom. Needs its own design.
+
+### Status quo for the Subtype case
+
+The current behavior, as documentation: a Subtype value resolves NO spec, because
+its head type is `Subtype` (no `spytial_spec` attached) and `lookupTypeSpec` does
+not unwrap it. Expect `#spytial.typespec` to print `none` below even though `Nat`
+itself could carry a spec — confirming that Subtype inheritance is not (yet) wired.
+-/
+
+def aPositive : { x : Nat // x > 0 } := ⟨1, by decide⟩
+
+-- Expect: none (Subtype carries no spec; the base type's spec is not inherited).
+#spytial.typespec aPositive

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance]
   needs := #[widgetJsAll]
 
 require proofwidgets from

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,7 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels]
   needs := #[widgetJsAll]
 
 require proofwidgets from


### PR DESCRIPTION
## Summary

**PR 2 of 3** in a stacked series. This PR covers **commands and spec-layer operations** — user-facing surface area. Stacked on PR 1 (relationalizer term-shapes).

| Issue | Feature | How |
|-------|---------|-----|
| [#8](https://github.com/sidprasad/spytial-lean/issues/8) | **`#spytial.enumerate`** | New command renders all inhabitants of a finite type into one shared diagram. **No `Fintype`/Mathlib dependency** (uses the existing `tryEnumerateDomain`: `Bool`, `Fin n` for n ≤ 20, zero-arity enum inductives). `#spytial f` already enumerates finite function domains, so no `#spytial.map` variant. |
| [#24](https://github.com/sidprasad/spytial-lean/issues/24) | **`.notationLabel`** | New relationalizer-side spec op collapses a type-head's values into one atom labeled with the delaborator-resugared surface syntax (`[1, 2, 3]` instead of a `cons` chain). |
| [#2](https://github.com/sidprasad/spytial-lean/issues/2) | **Type-class spec inheritance** | Verified that Lean 4 classes (which *are* structures) already inherit specs through the existing parent-chain walk; added a demo proving it and a `#spytial.typespec` debug command. |

## Design notes
- **Relationalizer-side ops stay out of the widget YAML.** `.notationLabel` configures the *walk*, not the layout, so the five spec-evaluating elaborators were restructured to evaluate the spec first and partition it into `WalkConfig.collapseTypes` — keeping spytial-core's input exactly what `parseLayoutSpec` understands. When no `.notationLabel` op is present, command output is byte-identical to before. Type-attached specs reject the op with a clear error (YAML storage can't carry it yet).
- **No Mathlib in core** drove the `#spytial.enumerate` design.
- **#2 scope:** explicit-`extends` syntax, per-instantiation specs (`List Nat` vs `List`), and Subtype inheritance stay deferred with rationale in `PLAN.md`; the issue stays open.

## Demos
New: `Enumeration`, `NotationLabels`, `SpecInheritance`.

## Verification
`lake build` + `lake build Demos` green.

> **Stack:** base `feat/relationalizer-term-shapes` (PR 1). Followed by PR 3 (limits & proof-state). Review against PR 1 to see only this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
