### PR TITLE
Limits & proof-state: maxAtoms guard, spytial_goals tactic (#23 #10)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,25 @@
 
 This document records the design decisions for the open issue backlog and tracks
 implementation status. It is maintained in-repo so decisions survive the PRs that
-implement them. Last updated: 2026-06-10.
+implement them. Last updated: 2026-06-11.
+
+## Status at a glance
+
+| Issue | Feature | Status |
+|-------|---------|--------|
+| #22 | DAG-shared subterm flag | ✅ done |
+| #9 | Quotient type visualization | ✅ done |
+| #21 | Indexed-family index labels | ✅ done |
+| #13 | Structural function-body decomposition | ✅ done |
+| #8 | `#spytial.enumerate` finite types | ✅ done |
+| #24 | `.notationLabel` surface-syntax collapse | ✅ done |
+| #2 | Type-class spec inheritance | ✅ verified; rest deferred |
+| #23 | `maxAtoms` guard + benchmarks | ✅ done |
+| #10 | `spytial_goals` proof-state tactic | ✅ done (experimental) |
+| #20 | Mathlib smoke-test demo | 🔵 deferred (separate project) |
+
+Each landed feature ships with a demo under `demos/` registered in the `Demos`
+lib roots, and was verified with `lake build` + `lake build Demos`.
 
 ## Guiding principles
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,56 @@ Use `#spytial.datum` and `#spytial.spec` to inspect what the relationalizer and 
 ]
 ```
 
+## Performance and limits
+
+`walkExpr` is recursive and unbounded by depth; its cost scales with the number
+of atoms produced — roughly the number of constructor nodes after WHNF, minus
+shared subterms (structurally identical subterms are deduplicated into a single
+atom via the `seen` cache).
+
+Indicative timings, measured on a dev laptop (relationalize only — these are not
+rigorous benchmarks, and the widget's own layout step is separate and slower):
+
+| Input | Atoms | `relationalize` time |
+|-------|-------|----------------------|
+| `List.range 10` | 21 | < 5 ms |
+| `List.range 100` | 201 | ~ 3 ms |
+| `List.range 1000` | 2001 | ~ 40 ms |
+| Balanced binary tree, depth 5 (31 nodes, distinct leaves) | 47 | < 1 ms |
+| `Nat.add_comm 100 200` (proof mode, `filterProofs := false`) | 1 | < 1 ms |
+
+Relationalization itself stays fast into the low thousands of atoms. In practice
+the limit you hit first is legibility: under a few hundred atoms the diagram
+renders comfortably, but into the thousands the layout step inside the widget
+becomes the bottleneck and the picture is rarely readable anyway.
+
+### The `maxAtoms` guard
+
+`WalkConfig.maxAtoms` (default `5000`) caps the total number of atoms a single
+walk may produce. When a walk would exceed it, the relationalizer throws rather
+than building a runaway diagram (or hanging the editor):
+
+```
+spytial: relationalize produced over 5000 atoms (the WalkConfig.maxAtoms limit
+was hit); the term is too large to visualize usefully. Increase the limit via
+WalkConfig.maxAtoms, or visualize a smaller sub-term.
+```
+
+This guard bounds the **relationalizer**; the widget's own layout cost is a
+separate concern and is not affected by it. The default of 5000 is far above
+anything that renders usefully, so ordinary use never trips it — raise it
+deliberately if you genuinely need a larger diagram.
+
+### A note on unfolding
+
+`#spytial` decomposes a term *after* `Meta.whnf`, so definitions unfold before
+they are walked. A small-looking term can therefore expand a lot: `List.range
+1000` is three tokens but relationalizes to 2001 atoms. Proof terms are the
+surprising case in the other direction — a theorem like `Nat.add_comm 100 200`
+stays a single atom even in proof mode, because `whnf` does not unfold a
+theorem's body (proofs are opaque to it). So a proof that *looks* large may
+collapse to one node, while a tiny data definition may explode.
+
 ## Available operations
 
 Operations are constructors of `SpytialOp`. Pass them as a list to `with [...]` or `spytial_spec`.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,46 @@ Use `#spytial.datum` and `#spytial.spec` to inspect what the relationalizer and 
 ]
 ```
 
+## Commands and tactics
+
+Beyond `#spytial <term>` and the `spytial <term>` tactic, the library provides:
+
+| Form | Purpose |
+|------|---------|
+| `#spytial <term> with [...]` | Visualize a value (the core command). |
+| `#spytial.proof <term>` | Visualize a proof term — shows `Prop`-typed sub-proofs that `#spytial` filters out. |
+| `#spytial.enumerate <Type>` | Visualize **all** inhabitants of a finite type in one diagram. Enumerable types: `Bool`, `Fin n` (`n ≤ 20`), and inductive types whose constructors all take no arguments. No `Fintype` instance required. |
+| `spytial <term>` / `spytial.proof <term>` | The same, in tactic mode (hypotheses in scope). |
+| `spytial_goals` | **Experimental.** Render the current proof state — hypotheses and goals — as one relational diagram. First-order `Prop` hypotheses `R a b` become relation edges; goal relations are prefixed `⊢ `. See [issue #10](https://github.com/sidprasad/spytial-lean/issues/10). |
+
+Each command has a `.datum` debugging counterpart that prints JSON instead of
+opening the widget: `#spytial.datum`, `#spytial.proof.datum`,
+`#spytial.enumerate.datum`, and the `spytial_goals_datum` tactic.
+`#spytial.typespec <term>` prints the spec YAML resolved for a term's type
+(including inherited specs).
+
+```lean
+inductive Direction | north | south | east | west
+#spytial.enumerate Direction   -- four atoms, one per constructor
+
+-- A finite function is already enumerated by #spytial (no #spytial.map needed):
+def turn : Direction → Direction
+  | .north => .east | .east => .south | .south => .west | .west => .north
+#spytial turn                  -- the full mapping as edges
+```
+
+Notation-aware labels collapse the underlying constructor chain back to surface
+syntax:
+
+```lean
+#spytial ([1, 2, 3] : List Nat) with [.notationLabel (selector := "List")]
+-- one atom labeled `[1, 2, 3]` instead of a four-atom cons/nil chain
+```
+
+See the [`demos/`](demos/) directory for runnable examples of every feature,
+including DAG sharing, quotient types, indexed families (`Vec n`), and
+structural decomposition of function bodies.
+
 ## Performance and limits
 
 `walkExpr` is recursive and unbounded by depth; its cost scales with the number
@@ -218,6 +258,16 @@ Operations are constructors of `SpytialOp`. Pass them as a list to `with [...]` 
 | `.tag (toTag) (name) (value)` | Add computed attributes to nodes |
 | `.inferredEdge (name) (selector)` | Add edges that don't exist in the data |
 | `.flag (name)` | Set a boolean flag (e.g., `hideDisconnected`) |
+
+### Relationalizer ops
+
+These configure the *walk* rather than the widget, so they never appear in the
+emitted YAML. They are only valid in a `with [...]` block (not in a type-attached
+`spytial_spec`).
+
+| Operation | Description |
+|-----------|-------------|
+| `.notationLabel (selector)` | Collapse values whose type-head matches the selector into a single atom labeled with their surface notation — e.g. `.notationLabel (selector := "List")` renders `[1, 2, 3]` as one atom instead of a `cons` chain. Selectors use the type **head** name (`List`, `Prod`), not the applied type. |
 
 ### Direction values
 

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -452,4 +452,240 @@ def elabSpytialProofTactic : Tactic := fun stx => do
 
     savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
 
+/-! ## Proof-state tactic -/
+
+/-- Resolve a human-readable relation name from the head of a Prop application,
+    or `none` if the head is not something we name a relation after.
+
+    - A `.const R` head yields `R`'s short name (e.g. `LT.lt` → `lt`).
+    - A `.fvar` head yields the local declaration's user-facing name. This is the
+      common case for proof-state goals: a relation introduced by `variable (R :
+      α → α → Prop)` or a binder is a *free variable*, NOT a constant, so without
+      this branch `R x y` would never become a relation. The fvar must be in the
+      ambient local context (this runs inside `mvarId.withContext`).
+    - Anything else (a `∀`/`→`/`∧` whose head is not an application of a named
+      symbol) yields `none`, so the caller falls back to skipping / a `Goal`
+      atom. -/
+private def relNameOfHead? (head : Expr) : MetaM (Option String) := do
+  match head with
+  | .const n _ => return some (shortName n)
+  | .fvar fvarId =>
+    match (← getLCtx).find? fvarId with
+    | some decl => return some (shortName decl.userName)
+    | none      => return none
+  | _ => return none
+
+/-- Walk a Prop application `R a₁ … aₙ` (headed by a constant or a local free
+    variable) as a relation tuple.
+
+    Given an expression `ty` (a hypothesis or goal *type*), this:
+
+    - returns `false` (decomposed nothing) unless `ty` is `Meta.isProp` and its
+      head is a constant or local fvar `R` (see `relNameOfHead?` — local
+      relations from `variable (R : …)` are fvars, so both are accepted);
+    - filters the arguments to the non-proof, non-type *data* args (reusing the
+      same `isProofArg` predicate the value walker uses);
+    - if ≥ 2 data args survive, walks each as an atom via `walkExpr` and adds ONE
+      tuple to a relation named `{prefix}{R}` connecting them in order, returning
+      `true`;
+    - if exactly 1 data arg survives, walks it as a lone atom (it appears in the
+      diagram but carries no edge — a unary relation has no endpoints) and
+      returns `true`;
+    - if 0 data args survive, emits nothing and returns `false`.
+
+    `pfx` is prepended to the relation name: hypotheses pass `""`, goals pass
+    `"⊢ "`, so specs can style goal edges differently from hypothesis edges. The
+    relation name is R's short name, NOT the hypothesis binder name — the
+    relation carries the meaning, and the binder name is intentionally dropped
+    for now (a deliberate simplification; see the `spytial_goals` docstring). -/
+private def walkPropApp (cfg : WalkConfig) (pfx : String) (ty : Expr) :
+    StateT WalkState MetaM Bool := do
+  -- Only const-/fvar-headed Prop applications become relations.
+  unless ← Meta.isProp ty do return false
+  let some rName ← relNameOfHead? ty.getAppFn | return false
+  let relName := pfx ++ rName
+  -- Keep only the genuine data arguments. Drop proofs and types (as the value
+  -- walker does), AND drop instance arguments: a notation-class application like
+  -- `a < b` desugars to `@LT.lt Nat instLTNat a b`, and the `instLTNat` instance
+  -- is `Type`-valued (not a proof or sort) so it survives `isProofArg`. Walking
+  -- it would inject a spurious `LT.mk` node and make `lt` a 3-ary `[inst, a, b]`
+  -- relation instead of the intended binary `a → b`.
+  let args := ty.getAppArgs
+  let mut dataArgs : Array Expr := #[]
+  for a in args do
+    if ← isProofArg a then continue
+    -- Skip instances (arguments whose type is a type class).
+    if (← Meta.isClass? (← Meta.inferType a)).isSome then continue
+    dataArgs := dataArgs.push a
+  if dataArgs.size == 0 then
+    -- Nothing to anchor a relation on (e.g. `R` is a 0-ary or all-proof prop).
+    return false
+  -- Walk every surviving data arg into the shared diagram.
+  let mut ids : Array String := #[]
+  for a in dataArgs do
+    let id ← walkExpr cfg a
+    ids := ids.push id
+  if dataArgs.size == 1 then
+    -- A single data arg can't form an edge; its atom is already in the diagram.
+    return true
+  -- ≥ 2 data args: connect them in order with one tuple.
+  let types := Array.replicate ids.size relName
+  modify fun s => s.addTuple relName types { atoms := ids, types := types }
+  return true
+
+open Tactic in
+/-- `spytial_goals` renders the CURRENT proof state — all goals and their local
+    hypotheses — as a single spatial relational diagram in the Lean infoview.
+
+    For each goal (and inside each goal's own context, so hypotheses resolve):
+
+    - A hypothesis whose **type is a Prop application** `R a b …` headed by a
+      named symbol — a constant (`LT.lt a b` from `a < b`) OR a *local* free
+      variable (a relation from `variable (R : …)` or a binder; these are fvars,
+      not constants) — becomes a tuple in a relation named after `R` (the
+      hypothesis binder name, e.g. `h`, is *not* rendered — the relation name
+      carries the meaning). Only the data arguments are walked as atoms; proofs,
+      types, AND instance arguments (e.g. the `LT Nat` instance inside `a < b`)
+      are dropped. With ≥ 2 data args they are connected by one tuple; with
+      exactly 1, the lone atom appears with no edge; with 0, the hypothesis is
+      skipped.
+    - A **data hypothesis** (type is not a Prop, e.g. `t : Tree`) is
+      relationalized through the normal walker. An abstract hypothesis variable
+      (no definition) has no structure to descend into and renders as a single
+      atom typed by its type's head.
+    - A Prop hypothesis that is **not** a named-symbol application (e.g.
+      `∀ x, P x`, `A ∧ B`, `A → B`) is skipped; a one-line `logInfo` note reports
+      how many such hypotheses were skipped so they aren't silently missing.
+    - Each **goal** target gets the same Prop-application treatment, but its
+      relation name is prefixed `⊢ ` (so `.atomColor`/edge specs can distinguish
+      goal structure from hypotheses). A goal that is not a decomposable Prop
+      application becomes a single atom whose `type` field is `"Goal"` (so
+      `.atomColor (selector := "Goal")` works) and whose label is the
+      pretty-printed goal type.
+
+    Everything is walked into ONE shared diagram, so a hypothesis and a goal that
+    mention the same term point at the same atom.
+
+    Use `spytial_goals with [<ops>]` to attach layout operations, just like the
+    `spytial` tactic. There is no single subject type, so no `spytial_spec`
+    fallback applies; without a `with` block, no spec YAML is sent.
+
+    ```
+    example {α : Type} (R : α → α → Prop) (x y : α)
+        (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+      spytial_goals
+      exact hsymm x y h
+    ```
+
+    The diagram shows relation `R` with the tuple `x → y` (from `h`), the goal
+    relation `⊢ R` with the tuple `y → x`, and a note that `hsymm` (a `∀`) was
+    skipped.
+
+    **Experimental.** This tactic is new and its output shape may change. Stretch
+    goals from the issue — tactic diff (before/after a step), dependency
+    highlighting, and interactive selection — are not yet implemented. -/
+syntax (name := spytialGoalsTactic) "spytial_goals" (" with " term)? : tactic
+
+open Tactic in
+@[tactic spytialGoalsTactic]
+def elabSpytialGoalsTactic : Tactic := fun stx => do
+  let specOpt := stx[1]
+  -- Spec partitioning mirrors the other tactics: `.notationLabel` ops configure
+  -- the walk (collapsed types); the rest become YAML. There is no subject type,
+  -- so no type-attached spec fallback — without `with`, no YAML.
+  let (cfg, yaml) ← if specOpt.isNone then
+      pure ({ : WalkConfig }, none)
+    else do
+      let specTerm := specOpt[1]!
+      let spec ← evalSpytialSpec specTerm
+      pure ({ collapseTypes := spec.collapseTypes : WalkConfig },
+            some (SpytialSpec.toYaml spec.withoutRelationalizerOps))
+
+  -- `getGoals` lives in `TacticM`; snapshot the goal list here, then walk it all
+  -- inside one shared `StateT WalkState MetaM` so the diagram is shared.
+  let goals ← getGoals
+  let walk : StateT WalkState MetaM Nat := do
+    let mut skipped : Nat := 0
+    for mvarId in goals do
+      skipped ← mvarId.withContext do
+        let mut skipped := skipped
+        -- Hypotheses (skip implementation-detail decls).
+        for decl in ← getLCtx do
+          if decl.isImplementationDetail then continue
+          let hypTy ← instantiateMVars decl.type
+          if ← Meta.isProp hypTy then
+            -- Prop hypothesis: relation if it is a named-symbol (const/fvar)
+            -- application, else skip and count it for the note.
+            let decomposed ← walkPropApp cfg "" hypTy
+            unless decomposed do
+              skipped := skipped + 1
+          else
+            -- Data hypothesis: relationalize its fvar structurally.
+            let fv ← instantiateMVars decl.toExpr
+            let _ ← walkExpr cfg fv
+        -- Goal target.
+        let goalTy ← instantiateMVars (← mvarId.getType)
+        let decomposed ← walkPropApp cfg "⊢ " goalTy
+        unless decomposed do
+          -- Not a decomposable Prop application: a single `Goal`-typed atom.
+          let label ← ppLabel goalTy
+          modify fun s =>
+            let (atomId, s) := s.freshId
+            s.addAtom { id := atomId, type := "Goal", label := label }
+        return skipped
+    return skipped
+
+  let (skipped, state) ← walk.run {}
+  let di := state.toDataInstance
+
+  if skipped > 0 then
+    logInfo m!"spytial_goals: skipped {skipped} hypothesis(es) that are not \
+      relation applications (e.g. `∀`, `∧`, `→`)."
+
+  let props : Json := Json.mkObj <|
+    [("dataInstance", toJson di)] ++
+    match yaml with
+    | some s => [("cndSpec", toJson s)]
+    | none => []
+
+  savePanelWidgetInfo SpytialWidget.javascriptHash (return props) stx
+
+/-- `spytial_goals_datum` prints the JSON data instance for the current proof
+    state (the debugging counterpart of `spytial_goals`, mirroring the `.datum`
+    debug commands). It walks the same hypotheses and goals but `logInfo`s the
+    JSON instead of opening the widget, so the structure is visible in the build
+    log.
+
+    The keyword is `spytial_goals_datum` (underscore), not `spytial_goals.datum`:
+    in tactic position a trailing `.datum` lexes as a field projection rather than
+    part of the keyword, so the dotted form does not parse. The `#spytial.datum`
+    *command* can use a dot because `#`-prefixed command tokens are lexed whole. -/
+syntax (name := spytialGoalsDatumTactic) "spytial_goals_datum" : tactic
+
+open Tactic in
+@[tactic spytialGoalsDatumTactic]
+def elabSpytialGoalsDatumTactic : Tactic := fun _stx => do
+  let goals ← getGoals
+  let walk : StateT WalkState MetaM Unit := do
+    for mvarId in goals do
+      mvarId.withContext do
+        for decl in ← getLCtx do
+          if decl.isImplementationDetail then continue
+          let hypTy ← instantiateMVars decl.type
+          if ← Meta.isProp hypTy then
+            let _ ← walkPropApp ({ : WalkConfig }) "" hypTy
+          else
+            let fv ← instantiateMVars decl.toExpr
+            let _ ← walkExpr ({ : WalkConfig }) fv
+        let goalTy ← instantiateMVars (← mvarId.getType)
+        let decomposed ← walkPropApp ({ : WalkConfig }) "⊢ " goalTy
+        unless decomposed do
+          let label ← ppLabel goalTy
+          modify fun s =>
+            let (atomId, s) := s.freshId
+            s.addAtom { id := atomId, type := "Goal", label := label }
+  let (_, state) ← walk.run {}
+  let json := toJson state.toDataInstance
+  logInfo m!"{json.pretty}"
+
 end SpytialLean

--- a/SpytialLean/Command.lean
+++ b/SpytialLean/Command.lean
@@ -628,10 +628,11 @@ def elabSpytialGoalsTactic : Tactic := fun stx => do
         let decomposed ← walkPropApp cfg "⊢ " goalTy
         unless decomposed do
           -- Not a decomposable Prop application: a single `Goal`-typed atom.
+          -- Allocate through `freshAtomId` so it respects `maxAtoms` like every
+          -- other atom-producing path.
           let label ← ppLabel goalTy
-          modify fun s =>
-            let (atomId, s) := s.freshId
-            s.addAtom { id := atomId, type := "Goal", label := label }
+          let atomId ← freshAtomId cfg
+          modify fun s => s.addAtom { id := atomId, type := "Goal", label := label }
         return skipped
     return skipped
 
@@ -681,9 +682,8 @@ def elabSpytialGoalsDatumTactic : Tactic := fun _stx => do
         let decomposed ← walkPropApp ({ : WalkConfig }) "⊢ " goalTy
         unless decomposed do
           let label ← ppLabel goalTy
-          modify fun s =>
-            let (atomId, s) := s.freshId
-            s.addAtom { id := atomId, type := "Goal", label := label }
+          let atomId ← freshAtomId ({ : WalkConfig })
+          modify fun s => s.addAtom { id := atomId, type := "Goal", label := label }
   let (_, state) ← walk.run {}
   let json := toJson state.toDataInstance
   logInfo m!"{json.pretty}"

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -53,6 +53,13 @@ structure WalkConfig where
       from `.notationLabel` spec ops (see `SpytialSpec.collapseTypes`). E.g.
       `["List"]` renders `[1, 2, 3]` as one atom rather than a cons chain. -/
   collapseTypes : List String := []
+  /-- Hard upper bound on the number of atoms a single walk may produce.
+      Relationalizing a very large term (a long `List`, a deeply unfolded proof)
+      can generate thousands of atoms, which hangs the widget's layout step and
+      is rarely legible anyway. When the count would exceed this limit the walker
+      throws a clear error instead of running away. Default 5000 is far above any
+      term that renders usefully; raise it deliberately if you really need to. -/
+  maxAtoms : Nat := 5000
 
 /-- Check if an expression is a proof or type (erased at runtime). -/
 def isProofArg (e : Expr) : MetaM Bool := do
@@ -155,16 +162,33 @@ structure CasesOnInfo where
   numIndices : Nat
   ctors : Array Name
 
+/-- Allocate a fresh atom id, enforcing `cfg.maxAtoms`.
+
+    Every atom-producing path runs through one of the `freshId` call sites, so
+    routing them all through this helper makes `maxAtoms` a hard cap on the total
+    atom count regardless of which walker (value, function body, matcher, …)
+    produced them. When the next id would push the count over the limit it throws
+    an actionable error instead of building a runaway diagram. The error text is
+    deterministic (it does not depend on hash ordering). -/
+def freshAtomId (cfg : WalkConfig) : StateT WalkState MetaM String := do
+  let s ← get
+  let (atomId, s) := s.freshId
+  if s.nextId > cfg.maxAtoms then
+    throwError "spytial: relationalize produced over {cfg.maxAtoms} atoms \
+      (the WalkConfig.maxAtoms limit was hit); the term is too large to \
+      visualize usefully. Increase the limit via WalkConfig.maxAtoms, or \
+      visualize a smaller sub-term."
+  set s
+  return atomId
+
 /-- Emit a single leaf atom for an already-reduced expression and return its id.
 
     Pretty-prints `e` *as given* (no further reduction). The structural walker
     uses this for leaves of a function body so that arithmetic on the bound
     variable keeps its surface form (`n * 2`) instead of being unfolded by the
     full `whnf` that `walkExpr` would apply at its entry. -/
-def emitLeaf (e : Expr) : StateT WalkState MetaM String := do
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+def emitLeaf (cfg : WalkConfig := {}) (e : Expr) : StateT WalkState MetaM String := do
+  let atomId ← freshAtomId cfg
   let typeName ← typeShortName (← Meta.inferType e)
   let label ← ppLabel e
   modify fun s => s.addAtom { id := atomId, type := typeName, label := label }
@@ -204,11 +228,12 @@ partial def walkExpr (cfg : WalkConfig := {}) (eOrig : Expr) : StateT WalkState 
 
   let ty ← Meta.inferType e
 
-  -- Allocate a fresh ID and mark as seen immediately (before recursing)
-  let s ← get
-  let (atomId, s) := s.freshId
-  let s := s.markSeen hash atomId
-  set s
+  -- Allocate a fresh ID (enforcing `maxAtoms`) and mark as seen immediately
+  -- (before recursing). This is the single chokepoint every `walkExpr`-entry
+  -- atom flows through; `emitLeaf` and the structural walkers below allocate
+  -- via `freshAtomId` too, so the cap bounds the total regardless of path.
+  let atomId ← freshAtomId cfg
+  modify fun s => s.markSeen hash atomId
 
   -- Notation collapse: if this value's type-head short name was opted in via a
   -- `.notationLabel` spec op, emit ONE atom labeled with the surface notation of
@@ -436,9 +461,7 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
       let isDite := fnName == ``dite
       let ty ← Meta.inferType e
       let typeName ← typeShortName ty
-      let s ← get
-      let (atomId, s) := s.freshId
-      set s
+      let atomId ← freshAtomId cfg
       modify fun s => s.addAtom { id := atomId, type := typeName, label := "if" }
       let condId ← walkBody cfg args[1]!
       modify fun s => s.addTuple "condition" #[typeName, typeName]
@@ -469,15 +492,13 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
       -- a recursive call): emit a leaf from the surface form. Going through
       -- `walkExpr` here would full-`whnf` and unfold e.g. `n * 2` into
       -- `(n.mul 1).add n`; `emitLeaf` keeps the readable `n * 2`.
-      emitLeaf e
+      emitLeaf cfg e
   | .letE declName declType value body _nonDep =>
     -- Surface a `let`: walk the bound value, then the body with the let
     -- variable in scope as a local decl.
     let ty ← Meta.inferType e
     let typeName ← typeShortName ty
-    let s ← get
-    let (atomId, s) := s.freshId
-    set s
+    let atomId ← freshAtomId cfg
     modify fun s => s.addAtom { id := atomId, type := typeName, label := s!"let {declName}" }
     let valId ← walkBody cfg value
     modify fun s => s.addTuple "let_value" #[typeName, typeName]
@@ -500,7 +521,7 @@ partial def walkBody (cfg : WalkConfig := {}) (e : Expr) :
   | _ =>
     -- Bound variable, projection, or any other non-application head: emit a
     -- leaf from the surface form (e.g. the binder name `n`, or `n.fst`).
-    emitLeaf e
+    emitLeaf cfg e
 
 /-- Decompose a branch lambda: peel its binders (constructor fields, or a
     `dite` decidability proof), introducing a fresh local for each, then walk
@@ -525,9 +546,7 @@ partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
     StateT WalkState MetaM String := do
   let ty ← Meta.inferType e
   let typeName ← typeShortName ty
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+  let atomId ← freshAtomId cfg
   modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
   -- Discriminants sit right after the motive (one motive slot, then numDiscrs).
   let discrStart := mi.numParams + 1
@@ -565,9 +584,7 @@ partial def walkCasesOn (cfg : WalkConfig := {}) (e : Expr)
     StateT WalkState MetaM String := do
   let ty ← Meta.inferType e
   let typeName ← typeShortName ty
-  let s ← get
-  let (atomId, s) := s.freshId
-  set s
+  let atomId ← freshAtomId cfg
   modify fun s => s.addAtom { id := atomId, type := typeName, label := "match" }
   -- Major (the scrutinee) sits after params, motive, and indices.
   let majorPos := info.numParams + 1 + info.numIndices

--- a/SpytialLean/Relationalizer.lean
+++ b/SpytialLean/Relationalizer.lean
@@ -559,14 +559,18 @@ partial def walkMatch (cfg : WalkConfig := {}) (e : Expr)
     modify fun s => s.addTuple "match" #[typeName, typeName]
       { atoms := #[atomId, discrId], types := #[typeName, typeName] }
   -- Constructor order for branch labels comes from the discriminant's
-  -- inductive (single-discriminant matches are the common case).
+  -- inductive (single-discriminant matches are the common case). Guard on the
+  -- actual array: an under-applied matcher reached as a function body can leave
+  -- `discrs` empty even when `numDiscrs == 1`, and indexing would panic — the
+  -- branch loop already falls back to `case_{i}` labels when `ctorNames` is empty.
   if mi.numDiscrs == 1 then
-    let dty ← Meta.inferType discrs[0]!
-    match (← Meta.whnf dty).getAppFn with
-    | .const indName _ =>
-      if let some (.inductInfo iv) := (← getEnv).find? indName then
-        ctorNames := iv.ctors.toArray.map shortName
-    | _ => pure ()
+    if let some discr0 := discrs[0]? then
+      let dty ← Meta.inferType discr0
+      match (← Meta.whnf dty).getAppFn with
+      | .const indName _ =>
+        if let some (.inductInfo iv) := (← getEnv).find? indName then
+          ctorNames := iv.ctors.toArray.map shortName
+      | _ => pure ()
   -- One edge per alternative; the branch body is a lambda over its ctor fields.
   let alts := args.extract altStart args.size
   for h : i in [:alts.size] do

--- a/demos/ProofState.lean
+++ b/demos/ProofState.lean
@@ -1,0 +1,118 @@
+import SpytialLean
+
+open SpytialLean
+
+/-! # Proof-state visualization (`spytial_goals`)
+
+The `spytial_goals` tactic renders the CURRENT proof state — every goal and its
+local hypotheses — as one spatial relational diagram, instead of visualizing a
+single named value the way `spytial`/`#spytial` do.
+
+How the proof state maps to relations and atoms:
+
+- A hypothesis whose **type is a Prop application** `R a b …` headed by a named
+  symbol — either a constant (`LT.lt a b` from `a < b`) or a *local* relation
+  introduced by a binder / `variable (R : …)` (which is a free variable, not a
+  constant) — becomes a tuple in a relation named after `R`. The hypothesis
+  binder name (e.g. `h`) is *not* rendered — the relation name carries the
+  meaning. Only the data arguments are walked as atoms; proofs, types, and
+  instance arguments (e.g. the `LT Nat` instance inside `a < b`) are dropped.
+- A **data hypothesis** (a non-Prop type, e.g. `t : Tree`) is walked through the
+  normal relationalizer into the same diagram. An *abstract* hypothesis variable
+  (no definition) has no constructor structure, so it renders as a single atom
+  typed by its type's head; a let-bound or concrete value decomposes.
+- A Prop hypothesis that is **not** a named-symbol application (e.g. `∀ x, P x`,
+  `A ∧ B`, `A → B`) is skipped, with a one-line `logInfo` note so it isn't
+  silently missing.
+- Each **goal** target gets the same Prop-application treatment, but its relation
+  name is prefixed `⊢ ` so a spec can style goal structure differently from
+  hypotheses. A goal that is not a decomposable Prop application becomes a single
+  atom whose `type` field is `"Goal"`.
+
+It is **experimental**: the output shape may change. Tactic diff, dependency
+highlighting, and interactivity remain stretch goals (see issue #10).
+
+Because tactics run during elaboration, `lake build Demos` exercises everything
+below. The `spytial_goals_datum` calls print their JSON to the build log, which
+is the verification mechanism — no infoview required.
+-/
+
+/-! ## The motivating example: a symmetric relation
+
+`R` is a *local* relation (a `variable`, hence a free variable rather than a
+constant), and `spytial_goals` still names a relation after it. `h : R x y`
+becomes the relation `R` with the tuple `x → y`. The goal `R y x` becomes the
+goal relation `⊢ R` with the tuple `y → x`. The hypothesis
+`hsymm : ∀ a b, R a b → R b a` is a `∀`, not a relation application, so it is
+skipped — and `spytial_goals` logs a note saying one hypothesis was skipped. -/
+
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+  spytial_goals
+  exact hsymm x y h
+
+-- The same proof state inspected as JSON (printed to the build log): two
+-- relations — `R` with the tuple `x → y` (from `h`) and `⊢ R` with `y → x`
+-- (from the goal). Four atoms: `α` and `R` (the data hypotheses, walked as
+-- leaves), and `x`, `y` (shared between the `R` tuple and the `⊢ R` tuple, so
+-- both edges point at the SAME two nodes). `hsymm` (a `∀`) is skipped, with the
+-- one-line skip note.
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (h : R x y) (hsymm : ∀ a b, R a b → R b a) : R y x := by
+  spytial_goals_datum
+  exact hsymm x y h
+
+/-! ## Mixed data + Prop hypotheses
+
+The data hypothesis `t : Tree` is an abstract local variable (no definition), so
+it has no constructor structure to descend into and renders as a single
+`Tree`-typed atom labeled `t`. Alongside it, the Prop hypothesis `hlt : a < b`
+is a const-headed application — `a < b` desugars to `@LT.lt Nat instLTNat a b`,
+whose *data* args (after dropping the type, the `LT Nat` instance, and any
+proofs) are `a` and `b` — so it becomes the relation `lt` with the tuple
+`a → b`. Data atom and relational edge coexist in the *same* diagram. -/
+
+inductive Tree where
+  | leaf : Tree
+  | node (key : Nat) (left : Tree) (right : Tree) : Tree
+  deriving Repr
+
+-- `t` and `hlt` are consumed by `spytial_goals` (it reads them out of the local
+-- context), but the syntactic linter only sees uses in the *proof term*, where
+-- they don't appear — hence we silence the unused-variable warning here.
+set_option linter.unusedVariables false in
+example (t : Tree) (a b : Nat) (hlt : a < b) : True := by
+  spytial_goals
+  trivial
+
+-- JSON view of the mixed state: one `Tree`-typed atom for `t`, the `lt` relation
+-- with the binary tuple `a → b` (the instance arg correctly dropped), and a
+-- `Goal`-typed atom for the `True` goal (`True` is a nullary prop — no data args
+-- to anchor a relation — so it falls back to a single `Goal` atom).
+set_option linter.unusedVariables false in
+example (t : Tree) (a b : Nat) (hlt : a < b) : True := by
+  spytial_goals_datum
+  trivial
+
+/-! ## Multiple goals
+
+`constructor` splits an `And` goal into two subgoals. With ≥ 2 goals open,
+`spytial_goals` walks BOTH into one diagram: each `P`/`Q` goal target becomes its
+own `⊢`-prefixed structure (here, single `Goal` atoms, since `P` and `Q` are
+opaque propositions sharing no const head). -/
+
+example (P Q : Prop) (hp : P) (hq : Q) : P ∧ Q := by
+  constructor
+  spytial_goals_datum
+  · exact hp
+  · exact hq
+
+-- A multi-goal state where the goals ARE relation applications: after
+-- `constructor` on `R x y ∧ R y x`, both subgoals decompose into `⊢ R` tuples
+-- (`x → y` and `y → x`) in the shared diagram.
+example {α : Type} (R : α → α → Prop) (x y : α)
+    (hxy : R x y) (hyx : R y x) : R x y ∧ R y x := by
+  constructor
+  spytial_goals
+  · exact hxy
+  · exact hyx

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,7 +72,8 @@ lean_lib SpytialLean where
 lean_lib Demos where
   srcDir := "demos"
   roots := #[`Showcase, `ProofFieldFiltering, `FunctionFields, `TypeClassInstances, `CustomRelationalizer,
-             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance]
+             `Sharing, `Quotients, `IndexedFamilies, `Enumeration, `NotationLabels, `SpecInheritance,
+             `ProofState]
   needs := #[widgetJsAll]
 
 require proofwidgets from


### PR DESCRIPTION
## Summary

**PR 3 of 3** in a stacked series. This PR covers **safety limits and the experimental proof-state tactic**, plus the review-hardening and documentation pass. Stacked on PR 2 (commands & spec ops).

| Issue | Feature | How |
|-------|---------|-----|
| [#23](https://github.com/sidprasad/spytial-lean/issues/23) | **Size limits** | `WalkConfig.maxAtoms` (default 5000) caps total atoms via a single `freshAtomId` chokepoint that every atom-producing path routes through; exceeding it throws an actionable error instead of hanging the editor. README gains a "Performance and limits" section with measured timings. |
| [#10](https://github.com/sidprasad/spytial-lean/issues/10) | **`spytial_goals` (experimental)** | New tactic walks the current proof state into one diagram: first-order Prop hypotheses `R a b` become relation edges, goals get a `⊢ ` relation-name prefix so specs can style them distinctly. Companion `spytial_goals_datum` prints JSON. |

## Also included
- **Review hardening** (`8cc06d5`): a guard against an elaborator panic on an under-applied matcher in `walkMatch` (PR 1 code), and routing the `spytial_goals` goal-atom fallbacks through `freshAtomId` for consistent `maxAtoms` enforcement. These came out of an adversarial review of the combined diff.
- **Docs** (`00dc4e4`): README "Commands and tactics" reference (`#spytial.enumerate`, `spytial_goals`, the `.datum`/`.typespec` debug family), a `.notationLabel` operations entry, and the PLAN.md status table.

## Design notes
- **`spytial_goals` is experimental** — relation extraction is best-effort for first-order propositions; `∀`/`∧`/`→` hypotheses are skipped with a logged note. Tactic diff, dependency highlighting, and interactivity remain stretch goals; the issue stays open.
- `maxAtoms` bounds the **relationalizer**; the widget's own layout cost is separate (documented).

## Deferred (not in this PR)
[#20](https://github.com/sidprasad/spytial-lean/issues/20) (Mathlib smoke-test demo) is deferred to a standalone project — an optional Mathlib `lean_lib` would force multi-GB resolution on every `lake update`/CI run, and it needs a human reviewing rendered output. Rationale in `PLAN.md`.

## Verification
`lake build` + `lake build Demos` green, including a clean-from-scratch rebuild. New demo: `ProofState`.

> **Stack:** base `feat/commands-spec-ops` (PR 2). This is the top of the stack; merge after PR 1 and PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
